### PR TITLE
Round 2: six defects found on a second pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Copy [`.env.example`](.env.example) and adjust. These are all read by `app.py` o
 | `MAX_UPLOAD_MB`         | Upload size limit; larger requests get a 413.                      | `64`       |
 | `MAX_PAGES`             | Maximum pages per PDF.                                             | `200`      |
 | `RENDER_BATCH_SIZE`     | Pages rendered per Poppler call — this is what bounds peak memory. | `4`        |
+| `STALE_TASK_TIMEOUT`    | Seconds without progress before a conversion is reported as failed.| `1800`     |
 | `SESSION_COOKIE_SECURE` | `true` when serving over HTTPS: marks the cookie Secure, adds HSTS.| `false`    |
 | `LOG_LEVEL`             | Python logging level.                                              | `INFO`     |
 | `LOG_FILE`              | If set, also log to this file (rotating, 10 MB x 3).               | stdout only|

--- a/app.py
+++ b/app.py
@@ -48,8 +48,29 @@ UPLOAD_FOLDER = os.environ.get('UPLOAD_FOLDER', 'uploads')
 ALLOWED_EXTENSIONS = {'pdf'}
 SUPPORTED_ENGINES = {'tesseract', 'easyocr', 'pyocr', 'paddleocr'}
 SUPPORTED_OUTPUT_FORMATS = {'docx', 'txt', 'md', 'html'}
+
+
+def env_int(name: str, default: int, minimum: int = 1) -> int:
+    """Read a positive integer setting, failing with a message that names it.
+
+    These are documented, user-set knobs; a bare
+    `ValueError: invalid literal for int()` at import time gives an operator
+    nothing to go on when the container crash-loops.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw == '':
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        raise RuntimeError(f"{name} must be an integer, got {raw!r}") from None
+    if value < minimum:
+        raise RuntimeError(f"{name} must be >= {minimum}, got {value}")
+    return value
+
+
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
-app.config['MAX_CONTENT_LENGTH'] = int(os.environ.get('MAX_UPLOAD_MB', '64')) * 1024 * 1024
+app.config['MAX_CONTENT_LENGTH'] = env_int('MAX_UPLOAD_MB', 64) * 1024 * 1024
 app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(hours=1)  # Session timeout
 app.config['SESSION_COOKIE_HTTPONLY'] = True
 app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
@@ -93,6 +114,11 @@ os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 # Setup periodic cleanup
 CLEANUP_INTERVAL = 3600  # 1 hour in seconds
 TASK_TIMEOUT = 3600  # 1 hour in seconds
+# A conversion refreshes its record after every page, so a "processing" task
+# that has not been touched for this long is not slow, it is gone: the worker
+# was recycled or the container restarted mid-conversion. Without this the
+# progress page polls a task that will never finish.
+STALE_TASK_TIMEOUT = env_int('STALE_TASK_TIMEOUT', 1800)
 LAST_CLEANUP_TIME = time.time()
 
 
@@ -339,14 +365,22 @@ def check_dependency(name: str) -> Tuple[bool, Dict[str, Any]]:
     except Exception as e:
         return False, {"installed": False, "message": f"Error checking {name}: {str(e)}"}
 
+# Endpoints that must not create a session. Touching `session.permanent`
+# writes `_permanent` into the session dict, which marks it modified and makes
+# Flask emit Set-Cookie — so an uptime monitor polling /healthz was being
+# handed a cookie on every probe.
+SESSIONLESS_ENDPOINTS = {'healthz', 'system_check', 'api_check_dependency', 'static'}
+
+
 @app.before_request
 def before_request():
     """Run before each request to perform housekeeping."""
     # Run cleanup periodically
     cleanup_old_files()
 
-    # Make session permanent but with a timeout
-    session.permanent = True
+    if request.endpoint not in SESSIONLESS_ENDPOINTS:
+        # Make session permanent but with a timeout
+        session.permanent = True
 
 
 # The page loads Tailwind from static/vendor and defines inline styles/handlers,
@@ -726,8 +760,19 @@ def save_as_markdown(text_results: Dict[int, str], output_path: str) -> None:
             if i < max(text_results.keys()):
                 f.write('---\n\n')
 
+def escape_html(text: str) -> str:
+    """Escape the characters that would otherwise close out of a text node."""
+    return (text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+                .replace('"', '&quot;'))
+
+
 def save_as_html(text_results: Dict[int, str], output_path: str, title: str = "Converted Document") -> None:
     """Save the extracted text results as a basic HTML file."""
+    # The title reaches here from the uploaded filename. secure_clean_filename
+    # already strips angle brackets, so this is defence in depth rather than a
+    # live hole — but the paragraphs below were escaped and the title was not,
+    # which is exactly the asymmetry that becomes a hole after a refactor.
+    title = escape_html(title)
     with open(output_path, 'w', encoding='utf-8') as f:
         f.write('<!DOCTYPE html>\n')
         f.write('<html lang="en">\n')
@@ -745,7 +790,7 @@ def save_as_html(text_results: Dict[int, str], output_path: str, title: str = "C
             paragraphs = text.split('\n\n')
             for para in paragraphs:
                 # Escape basic HTML characters
-                escaped_para = para.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+                escaped_para = escape_html(para)
                 f.write(f'<p>{escaped_para.strip()}</p>\n')
             # Add a visual separator or page break indicator
             if i < max(text_results.keys()):
@@ -754,11 +799,11 @@ def save_as_html(text_results: Dict[int, str], output_path: str, title: str = "C
         f.write('</body>\n')
         f.write('</html>\n')
 
-MAX_PAGES = int(os.environ.get('MAX_PAGES', '200'))
+MAX_PAGES = env_int('MAX_PAGES', 200)
 # Pages rendered per Poppler call. Rendering the whole document in one go
 # materialises every page as a full-resolution bitmap at once: a 100-page PDF
 # at 600 DPI is several GB of RSS, which the 2 GB container limit cannot hold.
-RENDER_BATCH_SIZE = int(os.environ.get('RENDER_BATCH_SIZE', '4'))
+RENDER_BATCH_SIZE = env_int('RENDER_BATCH_SIZE', 4)
 
 
 def save_output(results: Dict[int, str], output_format: str, output_path: str, base_filename: str) -> None:
@@ -886,9 +931,7 @@ def process_pdf_with_progress(pdf_path: str, conversion_id: str, ocr_engine: str
         pages_per_second = total_pages / elapsed_time if elapsed_time > 0 else 0
         logger.info(f"PDF processing completed. Pages: {total_pages}, Time: {elapsed_time:.2f}s, Pages/sec: {pages_per_second:.2f}, Output: {output_path}")
 
-        # Clean up original PDF after successful conversion
-        if os.path.exists(pdf_path):
-            os.remove(pdf_path)
+        # (the uploaded PDF is removed in the finally block, on every path)
 
         return True, output_path, output_filename # Return the actual path and filename
 
@@ -909,6 +952,15 @@ def process_pdf_with_progress(pdf_path: str, conversion_id: str, ocr_engine: str
                 logger.info(f"Cleaned up temporary directory: {temp_dir}") # Log temp dir cleanup
             except Exception as e:
                 logger.error(f"Error cleaning up temporary directory: {e}")
+
+        # Remove the uploaded PDF whatever the outcome. It used to be deleted
+        # only on the success path, so a failed conversion left the user's
+        # document sitting in the upload folder until the next daily sweep.
+        if os.path.exists(pdf_path):
+            try:
+                os.remove(pdf_path)
+            except OSError as e:
+                logger.warning(f"Could not remove uploaded PDF {pdf_path}: {e}")
 
 def run_task_in_background(func: callable, task_id: str, *args: Any, **kwargs: Any) -> str:
     """Run a conversion in a background thread, recording progress in the store."""
@@ -1046,11 +1098,36 @@ def owns_task(task_id: str) -> bool:
     return task_id in session.get('owned_tasks', [])
 
 
+def fail_if_stale(task_id: str, record: Dict[str, Any]) -> Dict[str, Any]:
+    """Mark an abandoned conversion as failed instead of leaving it pending.
+
+    The conversion refreshes its record after every page, so a task still
+    claiming to be "processing" long after its last update is not slow — its
+    worker was recycled or the container restarted. Nothing would ever have
+    moved it out of that state, so the progress page polled forever.
+    """
+    if record.get("status") != "processing":
+        return record
+    if time.time() - record.get("timestamp", 0) <= STALE_TASK_TIMEOUT:
+        return record
+
+    logger.warning(f"Task {task_id} has not progressed in {STALE_TASK_TIMEOUT}s; marking failed")
+    TASKS.update(
+        task_id,
+        status="failed",
+        error="The conversion stopped unexpectedly (the server may have restarted). Please try again.",
+    )
+    return TASKS.get(task_id) or record
+
+
 def get_owned_task(task_id: str) -> Optional[Dict[str, Any]]:
     """Fetch a task record, or None if it is missing or not ours."""
     if not owns_task(task_id):
         return None
-    return TASKS.get(task_id)
+    record = TASKS.get(task_id)
+    if record is None:
+        return None
+    return fail_if_stale(task_id, record)
 
 
 @app.route('/status/<task_id>')

--- a/templates/status.html
+++ b/templates/status.html
@@ -158,7 +158,7 @@
                 
                 <!-- Cancel button -->
                 <div class="mt-6 text-center">
-                    <a href="/" class="text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 text-sm">Cancel and return to home</a>
+                    <a href="/" class="text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 text-sm">Return to home (the conversion keeps running)</a>
                 </div>
             </div>
         </div>

--- a/test_app.py
+++ b/test_app.py
@@ -21,7 +21,7 @@ from app import (  # noqa: E402
     process_image, fix_common_ocr_errors, save_as_markdown, save_as_html,
     is_within_upload_folder, looks_like_pdf, save_output, cleanup_old_files,
     process_pdf_with_progress, parse_preprocess_options, otsu_threshold,
-    run_task_in_background, TASKS, TASK_TIMEOUT
+    run_task_in_background, env_int, TASKS, TASK_TIMEOUT, STALE_TASK_TIMEOUT
 )
 
 # Initialize colorama for colored terminal output
@@ -583,6 +583,68 @@ class TestOCRApp(unittest.TestCase):
         self.assertEqual(record["status"], "failed")
         self.assertIn("conversion exploded", record["error"])
 
+    def test_stale_processing_task_is_marked_failed(self):
+        """A conversion whose worker died must not stay pending forever.
+
+        The record refreshes after every page, so a "processing" task with an
+        old timestamp is abandoned. Nothing used to move it out of that state
+        and the progress page polled it indefinitely.
+        """
+        task_file = os.path.join(self.test_upload_folder, '.tasks', f'{self.TASK_ID}.json')
+        os.makedirs(os.path.dirname(task_file), exist_ok=True)
+        with open(task_file, 'w') as f:
+            json.dump({
+                "status": "processing", "progress": 40,
+                "timestamp": time.time() - (STALE_TASK_TIMEOUT + 60),
+            }, f)
+        self._own(self.TASK_ID)
+
+        with patch('app.logger'):
+            response = self.app.get(f'/api/task_status/{self.TASK_ID}')
+
+        data = json.loads(response.data)
+        self.assertEqual(data["status"], "failed")
+        self.assertIn("stopped unexpectedly", data["error"])
+
+    def test_recent_processing_task_is_left_alone(self):
+        task_id = self._make_task(status="processing", progress=40)
+        response = self.app.get(f'/api/task_status/{task_id}')
+        self.assertEqual(json.loads(response.data)["status"], "processing")
+
+    def test_health_and_diagnostic_endpoints_do_not_set_a_cookie(self):
+        """An uptime monitor polling /healthz was handed a session cookie."""
+        for path in ('/healthz', '/system-check'):
+            with patch('app.check_dependency', return_value=(True, {"installed": True})):
+                response = self.app.get(path)
+            self.assertIsNone(response.headers.get('Set-Cookie'), msg=path)
+
+    def test_save_as_html_escapes_the_title(self):
+        out = tempfile.mktemp(suffix='.html')
+        try:
+            save_as_html({0: "body"}, out, title='x"><script>alert(1)</script>')
+            content = open(out, encoding='utf-8').read()
+            self.assertNotIn("<script>", content)
+            self.assertIn("&lt;script&gt;", content)
+            self.assertIn("&quot;", content)
+        finally:
+            if os.path.exists(out):
+                os.remove(out)
+
+    def test_env_int_reports_the_variable_it_could_not_parse(self):
+        with patch.dict(os.environ, {'MAX_PAGES': 'abc'}):
+            with self.assertRaises(RuntimeError) as ctx:
+                env_int('MAX_PAGES', 200)
+        self.assertIn("MAX_PAGES", str(ctx.exception))
+        self.assertIn("abc", str(ctx.exception))
+
+        with patch.dict(os.environ, {'MAX_PAGES': '0'}):
+            with self.assertRaises(RuntimeError):
+                env_int('MAX_PAGES', 200)
+
+        # Unset and empty both fall back to the default.
+        with patch.dict(os.environ, {'MAX_PAGES': ''}):
+            self.assertEqual(env_int('MAX_PAGES', 200), 200)
+
     def test_save_output_rejects_unknown_format(self):
         with self.assertRaises(ValueError):
             save_output({0: "text"}, "exe", os.path.join(self.test_upload_folder, "x"), "x")
@@ -921,6 +983,10 @@ class TestConversionPipeline(unittest.TestCase):
 
         self.assertFalse(success)
         self.assertIn("limit is 2", message)
+        # The upload is removed on the failure path too; it used to be deleted
+        # only after a successful conversion, so a rejected document sat in the
+        # upload folder until the next daily sweep.
+        self.assertFalse(os.path.exists(pdf_path))
 
     def test_renders_in_batches_rather_than_all_at_once(self):
         """Peak memory depends on this: one Poppler call per RENDER_BATCH_SIZE."""


### PR DESCRIPTION
Follow-up to #3. A second read over the hardened code, with each finding verified against the running app before being fixed. 59 → 64 tests.

## Abandoned conversions stayed pending forever

A task record refreshes after every page, but nothing ever moved a `processing` task out of that state if its worker was recycled or the container restarted mid-conversion. The progress page polled it until its own 10-minute timeout, then offered a "refresh to check progress" link that would never change anything.

A task with no progress for `STALE_TASK_TIMEOUT` (default 1800s, configurable) is now reported as failed with an explanation the user can act on.

## A failed conversion left the uploaded PDF on disk

`os.remove(pdf_path)` sat on the success path only. Anything that errored — including a document rejected for exceeding `MAX_PAGES` — left the user's file in the upload folder until the next daily sweep. Moved into the `finally` block, so it happens on every path.

## `/healthz` and `/system-check` handed out a session cookie

Touching `session.permanent` writes `_permanent` into the session dict, which marks it modified and makes Flask emit `Set-Cookie`. Every probe from an uptime monitor was getting one. Those endpoints now skip the session entirely.

## `save_as_html` did not escape the document title

The paragraphs immediately below it were escaped and the title was not. `secure_clean_filename` strips angle brackets, so this was not reachable from an upload today — but it is exactly the asymmetry that turns into a hole after one refactor. Now escaped through a shared helper, quotes included.

## A malformed env value crashed the container with a bare `ValueError`

`MAX_PAGES=abc` produced `ValueError: invalid literal for int() with base 10: 'abc'` at import, which does not say which variable is at fault while the container crash-loops. `env_int()` names the variable, shows the value, and rejects non-positive numbers.

## "Cancel and return to home" never cancelled anything

Real cancellation is still a roadmap item. The link now says what it does rather than implying the job stops.

---

Every environment variable the code reads appears in the README table; `STALE_TASK_TIMEOUT` was added to it and to `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)