### PR TITLE
Keep Dependabot off the PaddleOCR 2.x pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,21 @@ updates:
       python-dependencies:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # app.py dispatches against the PaddleOCR *2.x* API: it passes
+      # use_angle_cls/cls/show_log and calls .ocr(). 3.x removed all three
+      # arguments and renamed the method to .predict(), so a major bump breaks
+      # the PaddleOCR engine outright.
+      #
+      # The dangerous part is that CI would not notice: paddleocr is a lazy
+      # import and is deliberately not installed in CI, so every check stays
+      # green while the engine is broken for anyone who selects it. That makes
+      # this a bump a human has to make together with the code change, not one
+      # to merge on a green tick.
+      - dependency-name: "paddleocr"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "paddlepaddle"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/app.py
+++ b/app.py
@@ -641,7 +641,20 @@ def process_image(i: int, image_path: str, ocr_engine: str, language: str, prepr
 
         elif ocr_engine == "paddleocr":
             try:
+                import paddleocr as paddleocr_module
                 from paddleocr import PaddleOCR
+
+                # This branch is written against the 2.x API. Say so plainly
+                # rather than letting 3.x fail with a bare TypeError about an
+                # unexpected keyword argument, which points at nothing useful.
+                installed_version = str(getattr(paddleocr_module, '__version__', ''))
+                if installed_version and not installed_version.startswith('2.'):
+                    return i, (
+                        f"[Error: PaddleOCR {installed_version} is installed, but this app "
+                        f"targets the 2.x API. Install it with "
+                        f"'pip install -r requirements-paddleocr.txt', or use another engine.]"
+                    )
+
                 # Map common ISO codes (3-letter Tesseract or 2-letter) to PaddleOCR codes
                 lang_map = {
                     'eng': 'en', 'en': 'en', 'ita': 'it', 'it': 'it',

--- a/test_app.py
+++ b/test_app.py
@@ -787,6 +787,7 @@ class TestOCRApp(unittest.TestCase):
         fake_reader.ocr.return_value = fake_result
         fake_paddle_cls = MagicMock(return_value=fake_reader)
         fake_module = MagicMock()
+        fake_module.__version__ = '2.7.0'   # the API this branch targets
         fake_module.PaddleOCR = fake_paddle_cls
 
         import sys
@@ -799,6 +800,31 @@ class TestOCRApp(unittest.TestCase):
         # Built with the PaddleOCR 2.x API and 'eng' mapped to 'en'
         fake_paddle_cls.assert_called_once_with(use_angle_cls=True, lang="en", show_log=False)
         fake_reader.ocr.assert_called_once_with(img_path, cls=True)
+
+    @patch('app.logger')
+    def test_process_image_paddleocr_3x_reports_the_mismatch(self, mock_logger):
+        """A 3.x install must say so, not fail with a bare TypeError.
+
+        The dispatch targets the 2.x API (use_angle_cls/cls/show_log, .ocr()).
+        CI cannot catch a bad bump here — paddleocr is a lazy import and is not
+        installed there — so the runtime message has to be the useful one.
+        """
+        img = Image.new('RGB', (100, 100), color='white')
+        img_path = os.path.join(self.test_upload_folder, 'paddle3.png')
+        img.save(img_path)
+
+        fake_module = MagicMock()
+        fake_module.__version__ = '3.7.0'
+
+        import sys
+        with patch.dict(sys.modules, {'paddleocr': fake_module}):
+            idx, text = process_image(0, img_path, "paddleocr", "eng")
+
+        self.assertEqual(idx, 0)
+        self.assertIn("3.7.0", text)
+        self.assertIn("targets the 2.x API", text)
+        # It must not have tried to build a reader with the removed arguments.
+        fake_module.PaddleOCR.assert_not_called()
 
     def test_cleanup_old_files_removes_old(self):
         """Call the app's own cleanup, not a reimplementation of it.


### PR DESCRIPTION
Dependabot opened #11 (`paddleocr` → `>=3.7`) and #13 (`paddlepaddle` → `>=3.3`). Both would break the PaddleOCR engine.

`app.py` dispatches against the **2.x** API: it constructs the reader with `use_angle_cls`/`show_log`, calls `.ocr(path, cls=True)`, and walks the nested `[[[box], (text, confidence)], ...]` result. PaddleOCR 3.x removed all three arguments and renamed the method to `.predict()`, with a different result shape.

What makes this worth a config rule rather than just closing the two PRs: **CI cannot catch it.** `paddleocr` is a lazy import and is deliberately not installed in CI, so lint, both test jobs and the Docker build all stay green while the engine is broken for anyone who selects it. A green tick is not evidence here.

- `.github/dependabot.yml`: ignore `version-update:semver-major` for `paddleocr` and `paddlepaddle`, with the reasoning inline so the next person does not simply delete the rule.
- `app.py`: if a non-2.x `paddleocr` is importable at runtime, return a message naming the installed version and pointing at `requirements-paddleocr.txt`, instead of failing with a bare `TypeError` about an unexpected keyword argument.

Moving to 3.x stays possible — it is a code change plus the bump, made together, which is exactly the thing a human should be doing rather than merging on a tick.

64 → 65 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)