### PR TITLE
Add CodeQL, clear the last Node 20 deprecation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      # Weekly rather than monthly: the monthly cadence left docker/login-action
+      # and docker/metadata-action a major behind for weeks after the rest of
+      # the workflow had moved on, which is how the Node 20 deprecation warning
+      # survived a full release cycle.
+      interval: "weekly"
 
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+# Static analysis for the paths that matter in this app: the upload handler's
+# file handling, the subprocess calls into the Tesseract and Poppler binaries,
+# and path construction around the upload folder.
+#
+# It runs on a schedule as well as on pushes because CodeQL's query pack is
+# updated independently of this repository — a query added next month can find
+# something in code that has not changed since today.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays, 04:17 UTC. Off the hour so as not to queue with everyone else's
+    # cron on the shared runners.
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # required to upload the results
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Initialise CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          # security-extended adds lower-severity security queries on top of
+          # the default set. The codebase is ~1.2k lines, so the extra noise is
+          # manageable and the extra coverage is worth it.
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -30,7 +30,7 @@ jobs:
 
       - name: Derive tags and labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |


### PR DESCRIPTION
Closes #17. Closes #22.

CodeQL was the one security signal never configured on this repo. Everything else is already in place — Dependabot security updates, secret scanning with push protection, no open alerts, and `pip-audit` clean against the pinned runtime dependencies — but `GET /code-scanning/alerts` returned *no analysis found*.

- **`codeql.yml`**: Python analysis with `security-extended`, on push, PR and a weekly schedule. The schedule earns its place: CodeQL's query pack updates independently of this repository, so a query added next month can find something in code that has not changed since today.
- **`release.yml`**: `docker/login-action` v3 → v4, `docker/metadata-action` v5 → v6. The last two actions still targeting Node 20.
- **`dependabot.yml`**: github-actions cadence monthly → weekly. The monthly interval is exactly why those two sat a major behind while the other five actions in the same file were bumped and shipped in v0.4.2.

`release.yml` only runs on a tag, so its two bumps are validated by the next release rather than by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)