### PR TITLE
Test on Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/test_app.py
+++ b/test_app.py
@@ -622,7 +622,8 @@ class TestOCRApp(unittest.TestCase):
         out = tempfile.mktemp(suffix='.html')
         try:
             save_as_html({0: "body"}, out, title='x"><script>alert(1)</script>')
-            content = open(out, encoding='utf-8').read()
+            with open(out, encoding='utf-8') as fh:
+                content = fh.read()
             self.assertNotIn("<script>", content)
             self.assertIn("&lt;script&gt;", content)
             self.assertIn("&quot;", content)
@@ -909,6 +910,9 @@ class TestOCRApp(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, b"converted text")
         self.assertIn('attachment', response.headers['Content-Disposition'])
+        # send_file keeps the file object open on the response; close it so the
+        # suite does not emit a ResourceWarning on every run.
+        response.close()
 
     def test_download_refuses_result_outside_upload_folder(self):
         outside = tempfile.mktemp(suffix='.txt')


### PR DESCRIPTION
Closes #18. Unblocks Dependabot #4.

The matrix stopped at 3.12, so merging #4 (base image `3.12-slim` → `3.14-slim`) would have shipped an image running on an interpreter no test covers.

**Verified against a real 3.14.6 locally before widening the matrix**, rather than assuming it would work: the pinned requirements resolve, all 65 tests pass, ruff is clean. That check earns its keep — pinning is precisely what silently invalidated the previously advertised *Python 3.9+*, because `click` 8.4 requires 3.10+.

Also closes two file handles the suite leaked, which made every run print `ResourceWarning`s: the HTML-escaping test read its output with a bare `open()`, and the download test left the file object `send_file` attaches to the response open. The suite now passes under `-W error::ResourceWarning` on both 3.12 and 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)