### PR TITLE
Act on CodeQL's first-run findings

### DIFF
--- a/app.py
+++ b/app.py
@@ -122,6 +122,18 @@ STALE_TASK_TIMEOUT = env_int('STALE_TASK_TIMEOUT', 1800)
 LAST_CLEANUP_TIME = time.time()
 
 
+def log_safe(value: Any, limit: int = 200) -> str:
+    """Flatten a value for logging so it cannot forge log structure.
+
+    Newlines in a logged value let an attacker append what look like genuine
+    log lines. Most of the values we log are already run through
+    `secure_filename` or an allowlist, but that guarantee lives far from the
+    log call — making it local means it cannot be lost by a later refactor.
+    """
+    text = str(value).replace('\r', ' ').replace('\n', ' ')
+    return text[:limit] + '...' if len(text) > limit else text
+
+
 class TaskStore:
     """Filesystem-backed store for background conversion tasks.
 
@@ -155,7 +167,7 @@ class TaskStore:
             with path.open(encoding='utf-8') as fh:
                 return json.load(fh)
         except (OSError, ValueError) as exc:
-            logger.error(f"Could not read task {task_id}: {exc}")
+            logger.error(f"Could not read task {log_safe(task_id)}: {exc}")
             return None
 
     def set(self, task_id: str, data: Dict[str, Any]) -> None:
@@ -170,7 +182,7 @@ class TaskStore:
                 json.dump(data, fh)
             tmp.replace(path)
         except OSError as exc:
-            logger.error(f"Could not write task {task_id}: {exc}")
+            logger.error(f"Could not write task {log_safe(task_id)}: {exc}")
 
     def update(self, task_id: str, **fields: Any) -> None:
         current = self.get(task_id)
@@ -185,7 +197,7 @@ class TaskStore:
             try:
                 path.unlink(missing_ok=True)
             except OSError as exc:
-                logger.warning(f"Could not delete task {task_id}: {exc}")
+                logger.warning(f"Could not delete task {log_safe(task_id)}: {exc}")
 
     def items(self):
         for path in sorted(self._dir().glob('*.json')):
@@ -313,7 +325,8 @@ def check_dependencies() -> Tuple[bool, str]:
         _dependency_check_cache[cache_key] = (now, result)
         return result
     except Exception as e:
-        result = (False, f"Error checking dependencies: {str(e)}")
+        logger.error(f"Error checking dependencies: {e}", exc_info=True)
+        result = (False, "Error checking dependencies. See the server log for details.")
         _dependency_check_cache[cache_key] = (now, result)
         return result
 
@@ -363,7 +376,11 @@ def check_dependency(name: str) -> Tuple[bool, Dict[str, Any]]:
             return False, {"installed": False, "message": f"Unknown dependency: {name}"}
     
     except Exception as e:
-        return False, {"installed": False, "message": f"Error checking {name}: {str(e)}"}
+        # The detail goes to the log, not to an anonymous HTTP caller: this
+        # endpoint needs no authentication, and exception text leaks paths and
+        # library internals.
+        logger.error(f"Error checking dependency {log_safe(name)}: {e}", exc_info=True)
+        return False, {"installed": False, "message": f"Error checking {log_safe(name)}"}
 
 # Endpoints that must not create a session. Touching `session.permanent`
 # writes `_permanent` into the session dict, which marks it modified and makes
@@ -1061,7 +1078,11 @@ def upload_file():
         orig_filename = secure_clean_filename(file.filename) or 'document.pdf'
 
         # Log processing request
-        logger.info(f"Processing request: file={orig_filename}, engine={ocr_engine}, lang={language}, quality={quality}, preprocess={preprocess}, format={output_format}")
+        logger.info(
+            f"Processing request: file={log_safe(orig_filename)}, engine={log_safe(ocr_engine)}, "
+            f"lang={log_safe(language)}, quality={quality}, preprocess={preprocess}, "
+            f"format={log_safe(output_format)}"
+        )
 
         # Create a temporary filename to avoid collisions
         pdf_path = os.path.join(app.config['UPLOAD_FOLDER'], f"{conversion_id}_{orig_filename}")
@@ -1260,8 +1281,10 @@ def system_check():
         "dependencies": {}
     }
     
-    # Check Python version
-    results["python_version"] = sys.version
+    # Major.minor only. The full sys.version string carries the patch level,
+    # build date and compiler — free fingerprinting for an endpoint that needs
+    # no authentication.
+    results["python_version"] = f"{sys.version_info.major}.{sys.version_info.minor}"
     
     # Check Tesseract
     try:
@@ -1272,9 +1295,10 @@ def system_check():
             results["status"] = "error"
             results["errors"].append("Tesseract OCR is not installed or not found in PATH")
     except Exception as e:
-        results["dependencies"]["tesseract"] = {"error": str(e)}
+        logger.error(f"Error checking Tesseract: {e}", exc_info=True)
+        results["dependencies"]["tesseract"] = {"error": "check failed"}
         results["status"] = "error"
-        results["errors"].append(f"Error checking Tesseract: {str(e)}")
+        results["errors"].append("Error checking Tesseract. See the server log for details.")
     
     # Check Poppler
     try:
@@ -1285,16 +1309,18 @@ def system_check():
             results["status"] = "error"
             results["errors"].append("Poppler is not installed or not found in PATH")
     except Exception as e:
-        results["dependencies"]["poppler"] = {"error": str(e)}
+        logger.error(f"Error checking Poppler: {e}", exc_info=True)
+        results["dependencies"]["poppler"] = {"error": "check failed"}
         results["status"] = "error"
-        results["errors"].append(f"Error checking Poppler: {str(e)}")
+        results["errors"].append("Error checking Poppler. See the server log for details.")
 
     # Check PaddleOCR (optional engine — reported for info, does not gate overall status)
     try:
         _, paddleocr_data = check_dependency('paddleocr')
         results["dependencies"]["paddleocr"] = paddleocr_data
     except Exception as e:
-        results["dependencies"]["paddleocr"] = {"error": str(e)}
+        logger.error(f"Error checking PaddleOCR: {e}", exc_info=True)
+        results["dependencies"]["paddleocr"] = {"error": "check failed"}
 
     # Check upload directory
     upload_dir = app.config['UPLOAD_FOLDER']

--- a/test_app.py
+++ b/test_app.py
@@ -21,8 +21,20 @@ from app import (  # noqa: E402
     process_image, fix_common_ocr_errors, save_as_markdown, save_as_html,
     is_within_upload_folder, looks_like_pdf, save_output, cleanup_old_files,
     process_pdf_with_progress, parse_preprocess_options, otsu_threshold,
-    run_task_in_background, env_int, TASKS, TASK_TIMEOUT, STALE_TASK_TIMEOUT
+    run_task_in_background, env_int, log_safe,
+    TASKS, TASK_TIMEOUT, STALE_TASK_TIMEOUT
 )
+
+def _temp_path(suffix: str) -> str:
+    """Reserve a temporary path without tempfile.mktemp.
+
+    `tempfile.mktemp` only returns a name, leaving a window in which another
+    process can create the file first; mkstemp creates it atomically.
+    """
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    os.close(fd)
+    return path
+
 
 # Initialize colorama for colored terminal output
 colorama.init(autoreset=True)
@@ -261,7 +273,7 @@ class TestOCRApp(unittest.TestCase):
 
     def test_save_as_markdown(self):
         test_results = {0: "Test page 1", 1: "Test page 2\n\nParagraph 2"}
-        test_output = tempfile.mktemp(suffix='.md')
+        test_output = _temp_path('.md')
         
         try:
             save_as_markdown(test_results, test_output)
@@ -283,7 +295,7 @@ class TestOCRApp(unittest.TestCase):
     
     def test_save_as_html(self):
         test_results = {0: "Test page 1", 1: "Test page 2\n\nParagraph 2", 2: "Test with <html> & entities"}
-        test_output = tempfile.mktemp(suffix='.html')
+        test_output = _temp_path('.html')
         test_title = "Test Document"
         
         try:
@@ -619,7 +631,7 @@ class TestOCRApp(unittest.TestCase):
             self.assertIsNone(response.headers.get('Set-Cookie'), msg=path)
 
     def test_save_as_html_escapes_the_title(self):
-        out = tempfile.mktemp(suffix='.html')
+        out = _temp_path('.html')
         try:
             save_as_html({0: "body"}, out, title='x"><script>alert(1)</script>')
             with open(out, encoding='utf-8') as fh:
@@ -645,6 +657,37 @@ class TestOCRApp(unittest.TestCase):
         # Unset and empty both fall back to the default.
         with patch.dict(os.environ, {'MAX_PAGES': ''}):
             self.assertEqual(env_int('MAX_PAGES', 200), 200)
+
+    def test_log_safe_flattens_forged_log_lines(self):
+        self.assertEqual(log_safe("normal.pdf"), "normal.pdf")
+        # A newline in a logged value would otherwise let an attacker append
+        # something that reads like a genuine log entry.
+        forged = "evil.pdf\n2026-01-01 - app - INFO - Admin logged in"
+        self.assertNotIn("\n", log_safe(forged))
+        self.assertNotIn("\r", log_safe("a\rb"))
+        # Long values are truncated rather than flooding the log.
+        self.assertLessEqual(len(log_safe("x" * 5000)), 210)
+
+    def test_system_check_does_not_leak_internals(self):
+        """It needs no authentication, so it must not fingerprint the host."""
+        with patch('app.check_dependency', side_effect=Exception("boom: /usr/local/secret")):
+            with patch('app.logger'):
+                response = self.app.get('/system-check')
+        body = response.data.decode()
+        self.assertNotIn("/usr/local/secret", body)
+        self.assertNotIn("boom", body)
+
+        data = json.loads(body)
+        # Major.minor only — the full sys.version carries patch level, build
+        # date and compiler.
+        self.assertRegex(data["python_version"], r'^\d+\.\d+$')
+
+    def test_check_dependency_error_does_not_reach_the_caller(self):
+        with patch('app.subprocess.check_output', side_effect=Exception("boom: /usr/local/secret")):
+            with patch('app.logger'):
+                installed, data = check_dependency('tesseract')
+        self.assertFalse(installed)
+        self.assertNotIn("secret", json.dumps(data))
 
     def test_save_output_rejects_unknown_format(self):
         with self.assertRaises(ValueError):
@@ -867,7 +910,7 @@ class TestOCRApp(unittest.TestCase):
 
     def test_save_as_markdown_empty(self):
         test_results = {}
-        test_output = tempfile.mktemp(suffix='.md')
+        test_output = _temp_path('.md')
         try:
             save_as_markdown(test_results, test_output)
             self.assertTrue(os.path.exists(test_output))
@@ -880,7 +923,7 @@ class TestOCRApp(unittest.TestCase):
 
     def test_save_as_html_empty(self):
         test_results = {}
-        test_output = tempfile.mktemp(suffix='.html')
+        test_output = _temp_path('.html')
         try:
             save_as_html(test_results, test_output, "EmptyDoc")
             self.assertTrue(os.path.exists(test_output))
@@ -915,7 +958,7 @@ class TestOCRApp(unittest.TestCase):
         response.close()
 
     def test_download_refuses_result_outside_upload_folder(self):
-        outside = tempfile.mktemp(suffix='.txt')
+        outside = _temp_path('.txt')
         with open(outside, 'w') as f:
             f.write("secret")
         try:


### PR DESCRIPTION
CodeQL, added in #23, reported **9 alerts on its first analysis**. Triaged and fixed rather than dismissed.

## Stack trace exposure — the real one

`/system-check` and `/api/check-dependency` need no authentication, and both handed exception text straight back to the caller. Exception strings from subprocess and import failures carry filesystem paths and library internals.

`/system-check` also returned the full `sys.version` — patch level, build date and compiler, i.e. free fingerprinting for an unauthenticated endpoint.

The detail now goes to the log, the caller gets a generic message, and the version is major.minor only.

## Log injection

User-controlled values were interpolated into log messages; a newline in one of them lets an attacker append text that reads like a genuine log line.

**Being straight about this one:** most of these values are already guarded — `secure_filename` strips newlines, and engine/format/language are allowlisted before the log call — so several alerts are technically false positives. `log_safe()` is still worth adding, because the guarantee currently lives far from the log statement, and a refactor could move a log call above its validation without anything noticing. Making it local costs one function.

## Insecure temporary files

The suite used `tempfile.mktemp`, which only reserves a *name*, leaving a window for another process to create the file first. Replaced with `mkstemp`, which creates it atomically.

---

65 → 68 tests: the endpoints do not echo exception text, the reported Python version is major.minor, and `log_safe` flattens a forged log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)