### PR TITLE
Correct the Dockerfile base-image comment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Python 3.9 reached end of life in October 2025 and stopped receiving security
-# fixes; 3.12 is the version the CI test matrix covers.
+# Kept in step with the CI test matrix, which covers 3.11 through 3.14.
+# Do not raise this past a version the matrix in ci.yml tests.
 FROM python:3.14-slim
 
 # Install required system dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-# Kept in step with the CI test matrix, which covers 3.11 through 3.14.
-# Do not raise this past a version the matrix in ci.yml tests.
+# Kept in step with the CI test matrix in .github/workflows/ci.yml, which
+# currently covers Python 3.11 to 3.14. Never set this higher than the highest
+# version that matrix tests, or the image ships on an untested interpreter.
 FROM python:3.14-slim
 
 # Install required system dependencies


### PR DESCRIPTION
Dependabot bumped the `FROM` line to `3.14-slim` in #4 but could not touch the comment above it, which still explained a choice of 3.12 and referenced Python 3.9's end of life.

Replaced with the rule that actually governs this line: it must not get ahead of the CI matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)