### PR TITLE
Close out advanced preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,14 @@ the code.
 These are referenced in the UI or were previously advertised, but are **not** in the code
 today. Contributions welcome.
 
-- **Advanced preprocessing** — denoising, deskewing, border removal, and the named preset
-  profiles (text-heavy / scanned / low-quality / handwriting). These need OpenCV, which is a
-  ~60 MB dependency, so they are not in the image yet. The controls have been removed from
-  the UI rather than left as no-ops; grayscale, sharpen, contrast and thresholding are real.
+- **Advanced preprocessing is out of scope, not pending.** Denoising, deskewing, border
+  removal and the named preset profiles were once checkboxes the server never read. They were
+  removed from the UI rather than stubbed, and after review they are not coming back: doing
+  them properly needs OpenCV, roughly 60 MB added to an image that already carries Tesseract
+  with a dozen language packs, for three checkboxes. Deskew is the only one that would
+  meaningfully help on crooked scans, and on its own it does not justify the weight. What
+  exists — grayscale, sharpen, a contrast slider and Otsu thresholding — is real, wired to the
+  form, and Pillow-only. If your scans need more than that, preprocess them before uploading.
 - **DOCX layout/formatting preservation** — output is currently plain paragraphs, not a
   faithful reproduction of the source layout.
 - **Heading / structure detection** in the output.


### PR DESCRIPTION
Decision on #20.

Denoising, deskewing and border removal have sat on the roadmap since the fake controls for them were removed from the UI in v0.4.0. Doing them properly needs OpenCV — about **60 MB** on an image that already carries Tesseract with a dozen language packs, for three checkboxes. Deskew is the only one that would meaningfully help crooked scans, and on its own it does not justify the weight.

So the README now says they are **out of scope**, rather than leaving an item that reads like work someone intends to do. What exists — grayscale, sharpen, a contrast slider and Otsu thresholding — is real, wired to the form, and Pillow-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)