### PR TITLE
Add a VitePress documentation site, and a check that keeps it honest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Run unit tests
         run: python -m unittest test_app -v
 
+      - name: Docs match the code
+        run: python scripts/check_docs_match_code.py
+
   docker:
     name: Docker image builds and serves
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,88 @@
+name: Docs
+
+# Builds the VitePress site and publishes it to GitHub Pages.
+# Pull requests build it too, without deploying, so a broken link or a failed
+# docs-vs-code check is caught before it merges rather than after.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/docs.yml'
+      - 'scripts/check_docs_match_code.py'
+      # The checker reads these, so a change to either can break the build.
+      - 'app.py'
+      - 'entrypoint.sh'
+      - 'README.md'
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0   # lastUpdated timestamps come from git history
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      # Cheap, and it is the check that stops the documentation drifting away
+      # from the code again.
+      - name: Docs match the code
+        run: python scripts/check_docs_match_code.py
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - name: Build
+        run: npm run docs:build
+
+      - name: Verify the required static files survived the build
+        run: |
+          set -e
+          for f in llms.txt robots.txt sitemap.xml favicon.svg .well-known/security.txt; do
+            test -s "docs/.vitepress/dist/$f" || { echo "missing or empty: $f"; exit 1; }
+          done
+          grep -q 'application/ld+json' docs/.vitepress/dist/index.html \
+            || { echo "JSON-LD missing from the home page"; exit 1; }
+          echo "all present"
+
+      - uses: actions/configure-pages@v5
+        if: github.ref == 'refs/heads/main'
+      - uses: actions/upload-pages-artifact@v4
+        if: github.ref == 'refs/heads/main'
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    name: Deploy to Pages
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ env/
 test_pdf_conversion.png
 test_pdf.pdf
 test_ocr.png
+
+# Docs site build
+node_modules/
+docs/.vitepress/dist/
+docs/.vitepress/cache/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Python Version](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+**📖 [Documentation](https://fabriziosalmi.github.io/pdf-ocr/)** — guide, configuration reference, HTTP endpoints, deployment and the threat model.
+
 A small **Flask web app** that turns scanned/image PDFs into editable text formats
 (**DOCX, TXT, Markdown, HTML**) using OCR. You upload a PDF in the browser, it renders
 each page to an image with Poppler, runs OCR (Tesseract by default), and gives you the
@@ -176,7 +178,8 @@ different promises.
 | POST   | `/cancel/<task_id>`         | Stops a running conversion at the next page boundary.            |
 | GET    | `/success/<task_id>`        | Result page for a finished conversion.                          |
 | GET    | `/download/<task_id>`       | Downloads the converted file.                                   |
-| GET    | `/new_conversion/<task_id>` | Discards a result and returns to the form.                      |
+| GET    | `/new_conversion/<task_id>` | Discards a result and its record, then returns to the form.     |
+| GET    | `/new_conversion`           | Returns to the form without discarding anything.                |
 | GET    | `/healthz`                  | Liveness probe; used by the image HEALTHCHECK.                  |
 | GET    | `/system-check`             | Dependency diagnostics as JSON.                                 |
 | GET    | `/api/check-dependency`     | Checks one dependency by `?name=`.                              |

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,130 @@
+import { defineConfig } from 'vitepress'
+
+// Project page on GitHub Pages: https://fabriziosalmi.github.io/pdf-ocr/
+const SITE = 'https://fabriziosalmi.github.io'
+const BASE = '/pdf-ocr/'
+const ORIGIN = SITE + BASE.replace(/\/$/, '')
+
+// Described once, emitted as JSON-LD on every page. SoftwareApplication is the
+// right type: this is a self-hosted application, not a hosted service.
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'pdf-ocr',
+  description:
+    'Self-hosted Flask web app that turns scanned PDFs into DOCX, TXT, Markdown or HTML using OCR.',
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Linux, macOS, Windows (via Docker)',
+  url: ORIGIN + '/',
+  codeRepository: 'https://github.com/fabriziosalmi/pdf-ocr',
+  downloadUrl: 'https://github.com/fabriziosalmi/pdf-ocr/releases',
+  installUrl: ORIGIN + '/guide/quickstart',
+  license: 'https://opensource.org/licenses/MIT',
+  programmingLanguage: 'Python',
+  isAccessibleForFree: true,
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'EUR' },
+  author: {
+    '@type': 'Person',
+    name: 'Fabrizio Salmi',
+    url: 'https://github.com/fabriziosalmi',
+  },
+}
+
+export default defineConfig({
+  title: 'pdf-ocr',
+  description:
+    'Self-hosted Flask web app that turns scanned PDFs into DOCX, TXT, Markdown or HTML using OCR.',
+  lang: 'en-GB',
+  base: BASE,
+  cleanUrls: true,
+  lastUpdated: true,
+
+  // Fail the build on a broken internal link rather than shipping one. The one
+  // exception is localhost, which is where the app runs and is not resolvable
+  // from the build — exempt that specific host rather than disabling the check.
+  ignoreDeadLinks: [/^https?:\/\/localhost/],
+
+  sitemap: {
+    hostname: ORIGIN + '/',
+  },
+
+  head: [
+    ['link', { rel: 'icon', href: BASE + 'favicon.svg', type: 'image/svg+xml' }],
+    ['meta', { name: 'theme-color', content: '#4f46e5' }],
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:site_name', content: 'pdf-ocr' }],
+    ['meta', { property: 'og:title', content: 'pdf-ocr — scanned PDFs to editable text' }],
+    [
+      'meta',
+      {
+        property: 'og:description',
+        content:
+          'Self-hosted Flask web app that turns scanned PDFs into DOCX, TXT, Markdown or HTML using OCR.',
+      },
+    ],
+    ['meta', { property: 'og:url', content: ORIGIN + '/' }],
+    ['meta', { name: 'twitter:card', content: 'summary' }],
+    ['script', { type: 'application/ld+json' }, JSON.stringify(structuredData)],
+  ],
+
+  themeConfig: {
+    outline: [2, 3],
+
+    nav: [
+      { text: 'Guide', link: '/guide/introduction', activeMatch: '/guide/' },
+      { text: 'Reference', link: '/reference/configuration', activeMatch: '/reference/' },
+      { text: 'Security', link: '/security' },
+      {
+        text: 'v0.5.1',
+        items: [
+          { text: 'Releases', link: 'https://github.com/fabriziosalmi/pdf-ocr/releases' },
+          { text: 'Container image', link: 'https://github.com/fabriziosalmi/pdf-ocr/pkgs/container/pdf-ocr' },
+          { text: 'Contributing', link: 'https://github.com/fabriziosalmi/pdf-ocr/blob/main/CONTRIBUTING.md' },
+        ],
+      },
+    ],
+
+    sidebar: {
+      '/guide/': [
+        {
+          text: 'Guide',
+          items: [
+            { text: 'Introduction', link: '/guide/introduction' },
+            { text: 'Quickstart', link: '/guide/quickstart' },
+            { text: 'Installation', link: '/guide/installation' },
+            { text: 'OCR engines', link: '/guide/engines' },
+            { text: 'Deployment', link: '/guide/deployment' },
+            { text: 'Troubleshooting', link: '/guide/troubleshooting' },
+          ],
+        },
+      ],
+      '/reference/': [
+        {
+          text: 'Reference',
+          items: [
+            { text: 'Configuration', link: '/reference/configuration' },
+            { text: 'HTTP endpoints', link: '/reference/endpoints' },
+            { text: 'How a conversion works', link: '/reference/pipeline' },
+          ],
+        },
+      ],
+    },
+
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/fabriziosalmi/pdf-ocr' },
+    ],
+
+    editLink: {
+      pattern: 'https://github.com/fabriziosalmi/pdf-ocr/edit/main/docs/:path',
+      text: 'Edit this page on GitHub',
+    },
+
+    search: { provider: 'local' },
+
+    footer: {
+      message:
+        'MIT licensed. <a href="/pdf-ocr/privacy">Privacy</a> · <a href="/pdf-ocr/security">Security</a> · <a href="/pdf-ocr/llms.txt">llms.txt</a>',
+      copyright: 'Copyright © 2025–2026 Fabrizio Salmi',
+    },
+  },
+})

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -1,0 +1,84 @@
+# Deployment
+
+Tagging `vX.Y.Z` publishes a multi-arch image (`linux/amd64` and `linux/arm64`) to
+`ghcr.io/fabriziosalmi/pdf-ocr`.
+
+## Docker run
+
+```bash
+docker run -d -p 8011:8011 \
+  -e SECRET_KEY="$(python -c 'import secrets; print(secrets.token_hex(32))')" \
+  -v "$PWD/uploads:/app/uploads" \
+  --read-only --tmpfs /tmp \
+  --cap-drop ALL --security-opt no-new-privileges \
+  ghcr.io/fabriziosalmi/pdf-ocr:v0.5.1
+```
+
+::: warning The hardening flags are not decoration
+The image runs as an unprivileged user (uid 10001) on its own. **The read-only root
+filesystem and the dropped capabilities come from the runtime**, not from the image — a bare
+`docker run` gives you neither. The app only ever writes to `/app/uploads` and `/tmp`, so
+these cost nothing.
+:::
+
+Prefer a version tag over `:latest` for anything you care about. `:latest` follows the
+default branch, and v0.4.0 was a breaking release.
+
+## Docker Compose
+
+`docker-compose.yml` sets the same options, and refuses to start without `SECRET_KEY`:
+
+```bash
+cp .env.example .env
+# set SECRET_KEY in .env
+docker compose up -d
+```
+
+## Behind a reverse proxy
+
+This is the intended deployment. The app has no authentication and no rate limiting, so the
+proxy is where both belong. Terminate TLS in front of it and set:
+
+```
+SESSION_COOKIE_SECURE=true
+```
+
+which marks the session cookie `Secure` and enables HSTS. Leave it `false` when serving over
+plain HTTP, or the browser will discard the cookie and no conversion will be visible to the
+session that started it.
+
+## Sizing
+
+Memory is dominated by page rendering, not by OCR. `RENDER_BATCH_SIZE` (default 4) is the
+number of pages Poppler renders in one call, and is what bounds peak usage — the whole
+document is never in memory at once. At 600 DPI a page is a large bitmap, so lower the batch
+size before lowering anything else if you are tight on RAM.
+
+`WEB_CONCURRENCY` (default 2) sets gunicorn worker processes. A conversion occupies one
+worker thread for its whole duration, so concurrent conversions need concurrent workers.
+
+## Health checks
+
+`/healthz` returns 200 when the upload folder is writable, and 503 when it is not. The image
+declares a `HEALTHCHECK` against it. It does not create a session or set a cookie, so an
+uptime monitor can poll it freely.
+
+```bash
+curl -fsS localhost:8011/healthz
+```
+
+`/system-check` gives a fuller diagnostic as JSON — dependency versions, upload directory
+state. It deliberately does **not** include exception text or the full Python version; those
+go to the log instead, because the endpoint needs no authentication.
+
+## Storage and cleanup
+
+Everything lives under `UPLOAD_FOLDER` (default `uploads`), including a `.tasks` directory of
+one JSON file per conversion. That is what lets more than one gunicorn worker serve the same
+conversion, and what lets progress survive a restart.
+
+Cleanup runs at most once an hour: files older than 24 hours are deleted, and task records —
+with the file each points at — are dropped an hour after their last update. A cancelled
+conversion leaves nothing behind at all.
+
+If you mount the volume, mount it at `/app/uploads`.

--- a/docs/guide/engines.md
+++ b/docs/guide/engines.md
@@ -1,0 +1,62 @@
+# OCR engines
+
+Tesseract is the default and the only one whose Python dependency is installed by default.
+The other three are optional and lazily imported, so they cost nothing until selected.
+
+| Engine | Install | Notes |
+|---|---|---|
+| **Tesseract** | included | Needs the `tesseract` binary. Fast, good on clean scans. |
+| **EasyOCR** | `pip install -r requirements-easyocr.txt` | Pulls in PyTorch. First run downloads language models, so it is slow once. |
+| **PyOCR** | `pip install pyocr` | A thin wrapper over the `tesseract` binary; needs it too. |
+| **PaddleOCR** | `pip install -r requirements-paddleocr.txt` | Heavy. **2.x only** — see below. |
+
+Each optional engine's requirements file layers on top of the pinned core, so installing one
+cannot quietly downgrade Flask or Pillow.
+
+## Languages
+
+The form offers `eng`, `fra`, `deu`, `spa`, `ita`, `por`, `chi_sim`, `chi_tra`, `jpn`, `kor`,
+`rus`, `ara`, `hin`, and one `+`-joined combination. The server accepts any `+`-joined set of
+Tesseract codes.
+
+The engines do not agree on language codes, so the app maps them:
+
+- **Tesseract and PyOCR** take the codes above as-is. The matching language pack must be
+  installed.
+- **EasyOCR** gets three-letter codes mapped to its two-letter ones (`ita` → `it`).
+- **PaddleOCR** loads one language per reader, so with a `+`-joined set it uses **the first
+  one**.
+
+## The PaddleOCR version pin
+
+The app is written against the **PaddleOCR 2.x** API: it builds the reader with
+`use_angle_cls` and `show_log`, calls `.ocr(path, cls=True)`, and walks the nested result
+shape. PaddleOCR 3.x removed all of that and renamed the method to `.predict()`.
+
+So `requirements-paddleocr.txt` pins `paddleocr>=2.6,<3.0`, and Dependabot is configured to
+ignore major updates for it.
+
+::: danger Why this is pinned rather than left to Dependabot
+`paddleocr` is a lazy import and is **not installed in CI**. A bump to 3.x would leave every
+check green while the engine was broken for anyone who selected it. Moving to 3.x is a code
+change plus the bump, made together.
+:::
+
+If a 3.x install is present at runtime, the app says so by name rather than failing with a
+`TypeError` about an unexpected keyword argument.
+
+## Preprocessing
+
+Opt-in, and applied before the image reaches the engine. Each control is read by the server:
+
+| Control | What it does |
+|---|---|
+| Grayscale | Converts to single-channel. |
+| Sharpen | A sharpening filter, helps soft scans. |
+| Contrast | Slider from 0.5 to 2.5, clamped server-side. |
+| Threshold | Binarises using an Otsu cutoff computed from the histogram. |
+
+Thresholding helps on clean document scans and hurts on photographs.
+
+Preprocessing reaches every engine, including the two that read the page from disk rather
+than taking the image object — they used to silently receive the untouched render.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,0 +1,70 @@
+# Installation
+
+## Requirements
+
+- **Python 3.11+**. CI runs the tests on 3.11, 3.12, 3.13 and 3.14; the Docker image uses
+  3.14. Python 3.9 and 3.10 are out — the pinned dependencies do not resolve on them.
+- **Tesseract OCR** — the binary, not just the Python wrapper.
+- **Poppler** — provides `pdftoppm`, which does the PDF rendering.
+
+Docker users can skip both binaries; they are in the image.
+
+## Installing the system binaries
+
+::: code-group
+```bash [macOS]
+brew install tesseract tesseract-lang poppler
+```
+```bash [Debian/Ubuntu]
+sudo apt-get install -y tesseract-ocr poppler-utils
+# plus language packs you need, e.g.
+sudo apt-get install -y tesseract-ocr-ita tesseract-ocr-fra
+```
+```powershell [Windows]
+# Tesseract: https://github.com/UB-Mannheim/tesseract/wiki
+# Poppler:   https://github.com/oschwartz10612/poppler-windows/releases
+# Add both to PATH, then restart your terminal.
+```
+:::
+
+Verify before going further — if either of these fails, the app will not work:
+
+```bash
+tesseract --version
+pdftoppm -v
+```
+
+## Installing the Python side
+
+```bash
+pip install -r requirements.txt
+```
+
+Versions are pinned. That is deliberate: floating bounds meant no two installs produced the
+same application, and a regression upstream was indistinguishable from one here. Dependabot
+proposes updates, and CI has to pass before they land.
+
+### The helper script
+
+```bash
+python install_dependencies.py
+python install_dependencies.py --engine all
+```
+
+It installs the pinned requirements and reports whether Tesseract and Poppler are reachable.
+`--engine` accepts `tesseract`, `easyocr`, `pyocr`, `paddleocr` or `all`. It **cannot** install
+the Tesseract or Poppler binaries — those are system packages.
+
+## Running the tests
+
+```bash
+pip install -r requirements.txt -r requirements-dev.txt
+ruff check .
+python -m unittest test_app -v
+```
+
+::: warning A green run can prove less than it looks
+Two groups need real binaries and **skip silently** without them: `TestConversionPipeline`
+needs Poppler, and `TestRealOCR` needs Tesseract. Install both, or you are running a smaller
+suite than the count suggests. CI installs both.
+:::

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -1,0 +1,74 @@
+# Introduction
+
+`pdf-ocr` takes a scanned or image-only PDF and gives you back text you can edit.
+
+The flow is deliberately simple, and worth knowing because almost every problem people hit
+maps onto one of these three steps:
+
+1. **Poppler** renders each page of the PDF to a PNG, at 300 or 600 DPI.
+2. An **OCR engine** reads that image and returns text.
+3. The text is written to **DOCX, TXT, Markdown or HTML**.
+
+If the output is empty, step 2 found nothing legible — usually a low-quality scan. If the
+conversion fails before it starts, step 1 could not read the PDF.
+
+## What it is for
+
+One person, running it themselves, converting their own documents. That is the whole design
+target. It is a good fit for a laptop, a home server, or a container on a private network.
+
+## What it is not
+
+It is **not** a hosted service, and it is not hardened to be one. There is no authentication
+and no rate limiting, both deliberately absent rather than half-built — see
+[Security](/security) for the full threat model. Anyone who can reach the port can convert
+documents and consume the CPU.
+
+Poppler and Tesseract are large C and C++ codebases that parse untrusted input. Putting this
+on the public internet exposes that parsing surface to everyone.
+
+## What works today
+
+- Upload → convert → download, with a live progress page.
+- Four output formats: DOCX, TXT, Markdown, HTML.
+- Four OCR engines: Tesseract (default), EasyOCR, PyOCR, PaddleOCR.
+- Language selection, including `+`-joined combinations for Tesseract.
+- Opt-in preprocessing: grayscale, sharpen, a contrast slider, Otsu binarisation.
+- Standard (300 DPI) or high (600 DPI) rendering.
+- Cancelling a running conversion, which stops at the next page boundary and leaves nothing
+  behind.
+- Conversions scoped to the browser session that started them.
+- A Docker image with Tesseract and Poppler already inside.
+
+## What it does not do
+
+Two lists, because "not got to it" and "decided against" are different promises.
+
+**Decided against**
+
+- **Advanced preprocessing** — denoise, deskew, border removal, preset profiles. These need
+  OpenCV, roughly 60 MB on an image that already carries Tesseract with a dozen language
+  packs, for three checkboxes. Deskew is the only one that would meaningfully help crooked
+  scans, and alone it does not justify the weight. Preprocess such scans before uploading.
+- **Authentication and rate limiting** — absent on purpose. Use a proxy.
+
+**Not built yet**
+
+- DOCX layout preservation; output is plain paragraphs.
+- Heading and structure detection.
+- Parallel page processing within one conversion.
+- Batch or folder processing.
+
+## A note on trust
+
+Two things in this application were once untrue, and both are worth knowing about because
+the fixes are what the tests now defend:
+
+- The OCR clean-up pass applied blind substitutions — `0`→`O`, `1`→`I`, `5`→`S` — to text the
+  engine had already read correctly, corrupting every number in every document. It now only
+  adjusts whitespace and punctuation, and never rewrites a character.
+- The options panel offered ten controls the server never read. They were removed rather than
+  stubbed.
+
+If you find something the documentation claims but the code does not do, that is a bug worth
+reporting.

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -1,0 +1,95 @@
+# Quickstart
+
+Docker is the fastest path, because the image already contains Tesseract and Poppler.
+
+## With Docker Compose
+
+```bash
+git clone https://github.com/fabriziosalmi/pdf-ocr.git
+cd pdf-ocr
+cp .env.example .env
+sed -i.bak "s|^SECRET_KEY=.*|SECRET_KEY=$(python -c 'import secrets; print(secrets.token_hex(32))')|" .env && rm .env.bak
+docker compose up --build
+```
+
+Then open <http://localhost:8011>, drop a PDF on the page, pick an output format, and
+download the result.
+
+::: tip Why the SECRET_KEY step is not optional
+It signs the session cookie, and conversions are scoped to the session that started them. The
+app **refuses to start** without it. A key generated per process would differ in every
+gunicorn worker, so a conversion started on one worker would be invisible to the next
+request — which is exactly the bug this rule exists to prevent.
+:::
+
+## Without Docker
+
+You need two system binaries first. Python packages alone are not enough:
+
+::: code-group
+```bash [macOS]
+brew install tesseract poppler
+```
+```bash [Debian/Ubuntu]
+sudo apt-get install -y tesseract-ocr poppler-utils
+```
+:::
+
+Then:
+
+```bash
+pip install -r requirements.txt
+
+# Development server (Werkzeug, single-threaded, local use only)
+FLASK_ENV=development python app.py            # http://127.0.0.1:8011
+
+# Or the way the container serves it
+SECRET_KEY=$(python -c 'import secrets; print(secrets.token_hex(32))') \
+  gunicorn --bind 127.0.0.1:8011 --workers 2 --threads 4 app:app
+```
+
+::: warning Never set FLASK_ENV=development in a deployment
+It enables the Werkzeug debugger, which is arbitrary code execution over HTTP.
+:::
+
+## Check your toolchain
+
+```bash
+python ocr_test.py
+```
+
+It renders a small image, OCRs it, converts a generated PDF through Poppler, and prints a
+verdict per check. It exits non-zero if either binary is missing, so it is safe to use in a
+script.
+
+The running app answers the same question over HTTP:
+
+```bash
+curl -s localhost:8011/system-check | python -m json.tool
+```
+
+## What the output looks like
+
+Two OCR'd pages of an invoice, exported as Markdown, with `---` marking the page break —
+this is the literal output of the Markdown writer:
+
+```markdown
+ACME Corporation
+
+Invoice No. 2024-0042
+Date: 2024-11-03
+
+Total due: 1,250.00 EUR
+
+---
+
+Terms: Net 30 days.
+Thank you for your business.
+```
+
+HTML wraps each paragraph in `<p>`, escapes entities, and separates pages with
+`<hr class="page-break">`. DOCX writes one paragraph per block with a page break between
+pages — plain text, not a reproduction of the source layout.
+
+OCR quality depends entirely on the scan. Nothing here can recover text that is not legible
+in the image.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1,0 +1,83 @@
+# Troubleshooting
+
+Start here:
+
+```bash
+curl -s localhost:8011/system-check | python -m json.tool   # if it is running
+python ocr_test.py                                          # if it is not
+```
+
+## "SECRET_KEY environment variable is required"
+
+The app will not start without it. Generate one:
+
+```bash
+python -c 'import secrets; print(secrets.token_hex(32))'
+```
+
+For local development only, `FLASK_ENV=development` starts without it.
+
+## Tesseract not found
+
+Confirm `tesseract --version` works in the same shell that starts the app, and that the
+install directory is on `PATH`.
+
+There is no setting for the binary's location. On Windows the fallback is editing `app.py`
+to add, after the imports:
+
+```python
+pytesseract.pytesseract.tesseract_cmd = r'C:\Program Files\Tesseract-OCR\tesseract.exe'
+```
+
+Putting Tesseract on `PATH` is the better fix.
+
+## PDF conversion errors
+
+Confirm `pdftoppm -v` works and Poppler's `bin/` is on `PATH`. Restart the terminal after
+changing `PATH` — an already-open shell keeps the old one.
+
+## Empty or poor output
+
+In rough order of what helps:
+
+1. Switch to **high** quality (600 DPI). Small text at 300 DPI is often the whole problem.
+2. Enable preprocessing. **Threshold** helps clean document scans and hurts photographs.
+3. Check the **language** matches the document and that its Tesseract pack is installed.
+4. Try another engine — EasyOCR often does better on noisy or handwritten-ish input.
+
+OCR cannot recover text that is not legible in the image. If you cannot read it zoomed in,
+neither can the engine.
+
+## The progress page sits at the same percentage
+
+Progress updates after each page, so a large page at 600 DPI can look stuck for a while.
+
+If a conversion genuinely stops — the container restarted, or a worker was recycled — it is
+reported as failed after `STALE_TASK_TIMEOUT` (default 30 minutes) rather than staying
+pending forever. Raise it if you OCR very large pages on slow hardware.
+
+## "The requested conversion was not found"
+
+Conversions are scoped to the browser session that started them. This appears when the
+session cookie is missing or different:
+
+- A different browser, or a private window.
+- `SESSION_COOKIE_SECURE=true` while serving over plain HTTP — the browser discards the
+  cookie.
+- More than one gunicorn worker with **no** `SECRET_KEY` pinned, so each worker signs with a
+  different key. In a deployment this cannot happen: the app refuses to start.
+
+## A large PDF is rejected
+
+`MAX_PAGES` defaults to 200 and `MAX_UPLOAD_MB` to 64. Raise either. If it runs out of memory
+instead, lower `RENDER_BATCH_SIZE` or use standard quality.
+
+## The first EasyOCR run is very slow
+
+It downloads language models on first use. Subsequent runs are normal.
+
+## Cancelling does not stop it immediately
+
+By design. Cancellation takes effect at the next page boundary, because that is the only
+place a conversion can stop cleanly and leave nothing behind. A 600 DPI page can take a while
+to finish.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,63 @@
+---
+layout: home
+title: Scanned PDFs to editable text
+titleTemplate: pdf-ocr
+
+hero:
+  name: pdf-ocr
+  text: Scanned PDFs to editable text
+  tagline: A self-hosted Flask app that runs OCR over a PDF and gives you back DOCX, TXT, Markdown or HTML. Runs on your own machine; nothing is sent anywhere.
+  actions:
+    - theme: brand
+      text: Quickstart
+      link: /guide/quickstart
+    - theme: alt
+      text: Read the threat model first
+      link: /security
+    - theme: alt
+      text: GitHub
+      link: https://github.com/fabriziosalmi/pdf-ocr
+
+features:
+  - title: Four output formats
+    details: DOCX, plain text, Markdown and HTML. Page breaks are preserved as page breaks in each format.
+  - title: Four OCR engines
+    details: Tesseract by default. EasyOCR, PyOCR and PaddleOCR work once you install their optional dependencies.
+  - title: Bounded by design
+    details: Pages render in small batches, so peak memory does not grow with document length. Upload size and page count are both capped.
+  - title: It tells you the truth
+    details: The clean-up pass never rewrites a character the engine produced, and every control in the form is read by the server. Both of those were once false, and there are tests that keep them true.
+---
+
+## What this is, in one paragraph
+
+You upload a PDF in a browser. Poppler renders each page to an image, an OCR engine reads
+the image, and the recognised text is written to the format you picked. It is a **single-user,
+self-hosted tool** — there is no authentication and no rate limiting, deliberately, so it
+belongs on a private network or behind an authenticating proxy. The
+[threat model](/security) says exactly what it does and does not protect you from.
+
+## Try it in three commands
+
+```bash
+git clone https://github.com/fabriziosalmi/pdf-ocr.git
+cd pdf-ocr
+cp .env.example .env && docker compose up --build
+```
+
+Compose refuses to start until `SECRET_KEY` is set, so
+[the quickstart](/guide/quickstart) shows how to generate one first. Then open
+<http://localhost:8011>.
+
+## Or run the published image
+
+```bash
+docker run -d -p 8011:8011 \
+  -e SECRET_KEY="$(python -c 'import secrets; print(secrets.token_hex(32))')" \
+  -v "$PWD/uploads:/app/uploads" \
+  --read-only --tmpfs /tmp --cap-drop ALL --security-opt no-new-privileges \
+  ghcr.io/fabriziosalmi/pdf-ocr:v0.5.1
+```
+
+Those hardening flags are not decoration — see [Deployment](/guide/deployment) for what each
+one is doing and why a bare `docker run` gives you less than you might assume.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,48 @@
+# Privacy
+
+Two separate things are described here, and they have different answers: **the application
+you run**, and **this documentation site**.
+
+## The application
+
+`pdf-ocr` is software you run yourself. There is no hosted service, no account, and no
+telemetry of any kind. Nobody but you sees the documents you convert.
+
+Concretely, the application:
+
+- **sends nothing anywhere.** There is no analytics, no crash reporting, no update check, and
+  no outbound network call. The web page loads no third-party assets — Tailwind is vendored
+  into the repository, and the Content-Security-Policy is same-origin.
+- **stores your files on your own disk**, under `UPLOAD_FOLDER`. The uploaded PDF is deleted
+  as soon as the conversion ends, whether it succeeded, failed or was cancelled. The
+  converted file stays until you download and discard it, or until cleanup removes it — files
+  older than 24 hours are deleted, and task records an hour after their last update.
+- **stores no personal data of its own.** The session cookie holds a list of conversion ids
+  you started, nothing else. There is no identity to store.
+- **writes logs** containing filenames, chosen options and errors. They go to stdout by
+  default, and to a file only if you set `LOG_FILE`. They are yours.
+
+One caveat worth being explicit about: some OCR engines download **language models** on first
+use. EasyOCR and PaddleOCR fetch these from their own project infrastructure. That is a
+download of model data, not an upload — your documents are never involved — but it is an
+outbound connection, and it is theirs rather than ours. Tesseract, the default, does not do
+this: its language packs come from your system package manager.
+
+## This documentation site
+
+These pages are static files served by **GitHub Pages**. There is no analytics script, no
+cookie set by this site, and no tracking of any kind in the pages themselves.
+
+GitHub serves them, and as the host it processes request data — including IP addresses — for
+delivery and abuse prevention. That is governed by
+[GitHub's Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement),
+not by this project. If that matters to you, the entire site can be read from the
+[repository](https://github.com/fabriziosalmi/pdf-ocr/tree/main/docs) or built locally.
+
+The site's search runs entirely in your browser; queries are not sent anywhere.
+
+## Contact
+
+For anything about this project, including privacy questions, open an issue or email
+`fabrizio.salmi@gmail.com`. For a suspected vulnerability, use the private channel described
+on the [Security](/security) page instead.

--- a/docs/public/.well-known/security.txt
+++ b/docs/public/.well-known/security.txt
@@ -1,0 +1,12 @@
+# Security contact for the pdf-ocr project.
+# https://securitytxt.org/  (RFC 9116)
+#
+# This covers the source code and the published container image. It does not
+# cover any deployment you or anyone else runs — those are the operator's.
+
+Contact: https://github.com/fabriziosalmi/pdf-ocr/security/advisories/new
+Contact: mailto:fabrizio.salmi@gmail.com
+Expires: 2027-08-13T00:00:00.000Z
+Preferred-Languages: en, it
+Canonical: https://fabriziosalmi.github.io/pdf-ocr/.well-known/security.txt
+Policy: https://github.com/fabriziosalmi/pdf-ocr/blob/main/SECURITY.md

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="pdf-ocr">
+  <rect width="32" height="32" rx="6" fill="#4f46e5"/>
+  <path d="M9 8h9l5 5v11a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z" fill="#fff" opacity=".95"/>
+  <path d="M18 8v5h5" fill="#c7d2fe"/>
+  <rect x="10" y="16" width="12" height="1.8" rx=".9" fill="#4f46e5"/>
+  <rect x="10" y="20" width="8" height="1.8" rx=".9" fill="#4f46e5"/>
+</svg>

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,48 @@
+# pdf-ocr
+
+> A self-hosted Flask web application that converts scanned or image-only PDFs into editable
+> text — DOCX, TXT, Markdown or HTML — using OCR. Poppler renders each page to an image, an
+> OCR engine (Tesseract by default; EasyOCR, PyOCR and PaddleOCR are optional) reads it, and
+> the text is written to the chosen format. It runs on the user's own machine and sends
+> nothing anywhere.
+
+Important context for answering questions about this project:
+
+- It is **single-user and self-hosted**. There is deliberately **no authentication and no
+  rate limiting**; the intended deployment is a private network or an authenticating reverse
+  proxy. Do not describe it as a hosted service or as multi-tenant.
+- `SECRET_KEY` is **required** — the application refuses to start without it. The only
+  exceptions are `FLASK_ENV=development` and `PDF_OCR_TESTING=1`, both for local use only.
+- The container image runs as an unprivileged user, but the read-only root filesystem and
+  dropped capabilities are **runtime flags**, not properties of the image. A bare
+  `docker run` does not give you them.
+- PaddleOCR is pinned to the **2.x** line. The code targets that API; 3.x removed it. Do not
+  advise upgrading without a matching code change.
+- Supported Python versions are **3.11 to 3.14**. 3.9 and 3.10 do not resolve the pinned
+  dependencies.
+
+## Documentation
+
+- [Introduction](https://fabriziosalmi.github.io/pdf-ocr/guide/introduction): what it is, what it is for, and what it deliberately does not do
+- [Quickstart](https://fabriziosalmi.github.io/pdf-ocr/guide/quickstart): running it with Docker Compose or locally, and what the output looks like
+- [Installation](https://fabriziosalmi.github.io/pdf-ocr/guide/installation): system binaries, Python requirements, running the tests
+- [OCR engines](https://fabriziosalmi.github.io/pdf-ocr/guide/engines): the four engines, language-code mapping, preprocessing, and the PaddleOCR version pin
+- [Deployment](https://fabriziosalmi.github.io/pdf-ocr/guide/deployment): the published image, hardening flags, reverse proxy, sizing, health checks, storage
+- [Troubleshooting](https://fabriziosalmi.github.io/pdf-ocr/guide/troubleshooting): the common failures and what actually fixes them
+
+## Reference
+
+- [Configuration](https://fabriziosalmi.github.io/pdf-ocr/reference/configuration): every environment variable, its effect and its default
+- [HTTP endpoints](https://fabriziosalmi.github.io/pdf-ocr/reference/endpoints): all routes, upload parameters, status JSON, and the session-ownership rule
+- [How a conversion works](https://fabriziosalmi.github.io/pdf-ocr/reference/pipeline): the five stages, where state lives, and the failure states
+
+## Policy
+
+- [Security](https://fabriziosalmi.github.io/pdf-ocr/security): threat model, what it does and does not protect against, how to report a vulnerability
+- [Privacy](https://fabriziosalmi.github.io/pdf-ocr/privacy): what the application stores and transmits, and what this documentation site does
+
+## Source
+
+- [Repository](https://github.com/fabriziosalmi/pdf-ocr): the application is a single module, `app.py`
+- [Releases](https://github.com/fabriziosalmi/pdf-ocr/releases): v0.4.0 was a breaking release; read its notes before upgrading from 0.3.x
+- [Container image](https://github.com/fabriziosalmi/pdf-ocr/pkgs/container/pdf-ocr): `ghcr.io/fabriziosalmi/pdf-ocr`, multi-arch amd64 and arm64

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,5 @@
+# https://fabriziosalmi.github.io/pdf-ocr/
+User-agent: *
+Allow: /
+
+Sitemap: https://fabriziosalmi.github.io/pdf-ocr/sitemap.xml

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,69 @@
+# Configuration
+
+Every setting is an environment variable. Copy
+[`.env.example`](https://github.com/fabriziosalmi/pdf-ocr/blob/main/.env.example) and adjust.
+
+::: tip This table is checked against the code
+`scripts/check_docs_match_code.py` fails CI if the code reads a variable this table does not
+list, or if the table lists one the code no longer reads. It exists because this
+documentation drifted badly once before.
+:::
+
+## Required
+
+| Variable | Effect | Default |
+|---|---|---|
+| `SECRET_KEY` | Signs the session cookie. **The app refuses to start without it.** Generate with `python -c 'import secrets; print(secrets.token_hex(32))'`. | — |
+
+A key generated per process would differ in every gunicorn worker, so a conversion started
+on one worker would be invisible to the next request, and every restart would invalidate
+every session. Two escape hatches exist for local work only: `FLASK_ENV=development` and
+`PDF_OCR_TESTING=1`. Never use either in a deployment.
+
+## Serving
+
+| Variable | Effect | Default |
+|---|---|---|
+| `PORT` | Port to listen on. | `8011` |
+| `WEB_CONCURRENCY` | gunicorn worker processes. A conversion occupies one for its duration. | `2` |
+| `WEB_THREADS` | gunicorn threads per worker. | `4` |
+| `WEB_TIMEOUT` | gunicorn request timeout in seconds. Must cover a full upload, not a full conversion — conversions run in the background. | `120` |
+| `SESSION_COOKIE_SECURE` | `true` when serving over HTTPS: marks the cookie `Secure` and enables HSTS. Setting it while serving plain HTTP makes the browser discard the cookie. | `false` |
+
+The three `WEB_*` variables are read by `entrypoint.sh`, not by the application, so they
+apply to the container and to any gunicorn invocation that uses that script.
+
+## Limits
+
+| Variable | Effect | Default |
+|---|---|---|
+| `MAX_UPLOAD_MB` | Upload size limit. Larger requests get a 413. | `64` |
+| `MAX_PAGES` | Maximum pages per PDF. A longer document is rejected before rendering. | `200` |
+| `RENDER_BATCH_SIZE` | Pages rendered per Poppler call. **This is what bounds peak memory** — the whole document is never in memory at once. | `4` |
+| `STALE_TASK_TIMEOUT` | Seconds without progress before a conversion is reported as failed rather than left pending. | `1800` |
+
+All four are positive integers; a malformed value fails at startup with a message naming the
+variable rather than a bare `ValueError`.
+
+## Storage and logging
+
+| Variable | Effect | Default |
+|---|---|---|
+| `UPLOAD_FOLDER` | Where uploads, results and task records live. Mount your volume here. | `uploads` |
+| `LOG_LEVEL` | Python logging level. | `INFO` |
+| `LOG_FILE` | If set, also log to this file, rotating at 10 MB with 3 backups. Unset means stdout only. | unset |
+
+Logging to stdout is the default because that is what an orchestrator collects, and because a
+read-only or non-writable working directory should not stop the app from booting.
+
+## Environment
+
+| Variable | Effect | Default |
+|---|---|---|
+| `DOCKER_ENV` | `true` skips the local Tesseract and Poppler probes. Set inside the image, where both are known to be present. | `false` |
+| `FLASK_ENV` | `development` runs without `SECRET_KEY` and enables the Werkzeug debugger. | unset |
+
+::: danger FLASK_ENV=development is remote code execution
+The Werkzeug debugger executes arbitrary Python from the browser. It exists for local
+development only.
+:::

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -1,0 +1,75 @@
+# HTTP endpoints
+
+::: tip Checked against the code
+`scripts/check_docs_match_code.py` fails CI if the app registers a route this page does not
+document.
+:::
+
+## Conversion flow
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/` | Upload form. |
+| `POST` | `/upload` | Accepts the PDF, starts a conversion, redirects to its status page. |
+| `GET` | `/status/<task_id>` | Progress page. Polls the JSON endpoint below. |
+| `GET` | `/api/task_status/<task_id>` | Progress as JSON. |
+| `POST` | `/cancel/<task_id>` | Asks a running conversion to stop at the next page boundary. |
+| `GET` | `/success/<task_id>` | Result page for a finished conversion. |
+| `GET` | `/download/<task_id>` | Downloads the converted file. |
+| `GET` | `/new_conversion/<task_id>` | Discards a result and its record, then returns to the form. |
+| `GET` | `/new_conversion` | Returns to the form without discarding anything. |
+
+## Diagnostics
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/healthz` | 200 if the upload folder is writable, 503 if not. Used by the image `HEALTHCHECK`. |
+| `GET` | `/system-check` | Dependency diagnostics as JSON. |
+| `GET` | `/api/check-dependency` | Checks one dependency, by `?name=tesseract`, `poppler` or `paddleocr`. |
+
+The three diagnostic endpoints never create a session or set a cookie, so an uptime monitor
+can poll them without collecting one on every probe.
+
+## Access control
+
+**A conversion is readable only by the browser session that started it.** The status, cancel,
+success and download routes return 404 (or redirect) for a task the session does not own, so
+a task id on its own grants nothing. Task ids are server-generated UUIDs.
+
+There is **no authentication** on any of this. Anyone who can reach the port can start a
+conversion. See [Security](/security).
+
+## Upload parameters
+
+`POST /upload` takes a multipart form:
+
+| Field | Values | Notes |
+|---|---|---|
+| `file` | a PDF | Must have a `.pdf` extension **and** the `%PDF-` magic bytes. |
+| `ocr-engine` | `tesseract`, `easyocr`, `pyocr`, `paddleocr` | Allowlisted. |
+| `output-format` | `docx`, `txt`, `md`, `html` | Allowlisted. |
+| `language` | e.g. `eng`, `ita`, `eng+fra` | Letters and underscores, `+`-joined. |
+| `ocr-quality` | `standard` (300 DPI) or `high` (600 DPI) | Anything else is treated as standard. |
+| `preprocess` | `1` to enable | The master switch for the four options below. |
+| `pre-grayscale`, `pre-sharpen`, `pre-threshold` | `1` to enable | Only read when `preprocess=1`. |
+| `pre-contrast` | `0.5` to `2.5` | Clamped server-side. |
+
+Every field the form submits is read by the server. That was once not true — ten controls
+were submitted and discarded — and is now a rule.
+
+## Status JSON
+
+```json
+{
+  "status": "processing",
+  "step": "ocr",
+  "progress": 45,
+  "timestamp": 1786606731.9
+}
+```
+
+`status` is one of `processing`, `completed`, `failed` or `cancelled`. When it reaches a
+terminal state the response also carries a `redirect`. A `failed` record carries an `error`;
+a `cancelled` one deliberately does not, because the user asking to stop is not an error.
+
+The result's path on disk is never included.

--- a/docs/reference/pipeline.md
+++ b/docs/reference/pipeline.md
@@ -1,0 +1,99 @@
+# How a conversion works
+
+Useful when something goes wrong, because almost every failure belongs to exactly one of
+these stages.
+
+## 1. Upload
+
+The request is checked before anything touches disk:
+
+- `.pdf` extension **and** the `%PDF-` magic bytes. The extension alone says nothing about
+  content, and the file is about to be handed to Poppler.
+- Engine, output format and language against allowlists. The output format used to be
+  interpolated straight into the output path.
+- Size against `MAX_UPLOAD_MB`, enforced by Flask before the body is fully read.
+
+A UUID is generated, the file is saved as `<uuid>_<sanitised name>.pdf`, and the id is added
+to the session's list of owned conversions.
+
+## 2. Page count
+
+`pdfinfo` reports the page count. This is required rather than best-effort: it decides how
+the work is batched, and without it the whole document would have to be rendered just to
+find out how long it is. Over `MAX_PAGES`, the conversion is rejected here.
+
+## 3. Render and OCR, in batches
+
+The loop is the heart of it:
+
+```
+for each batch of RENDER_BATCH_SIZE pages:
+    check for cancellation
+    render those pages with Poppler at 300 or 600 DPI
+    for each page:
+        write the PNG, preprocess if asked
+        run the OCR engine
+        delete the PNG
+        update progress
+        check for cancellation
+```
+
+Batching is what keeps memory bounded. Rendering the whole document at once — which it used
+to do — is several gigabytes for a 100-page PDF at 600 DPI, well over a typical container
+limit.
+
+Cancellation is checked twice per batch because a single 600 DPI page can take a while.
+
+## 4. Clean-up pass
+
+Applied to each page's text. It **only** adjusts layout:
+
+- re-joins words hyphenated across a line break (`exam-\nple` → `example`)
+- removes spaces before closing punctuation
+- strips trailing whitespace
+- collapses runs of blank lines
+
+It never rewrites a character the engine produced. An earlier version substituted `0`→`O`,
+`1`→`I` and `5`→`S` globally, corrupting every number in every document; a regression test
+pins those specific substitutions as forbidden.
+
+Paragraph reflow — turning single newlines into spaces — is off by default, because it
+destroys tables, addresses and invoices.
+
+## 5. Assembly
+
+| Format | What is written |
+|---|---|
+| DOCX | One paragraph per page's text, with a page break between pages. |
+| TXT | Text with `--- Page Break ---` between pages. |
+| Markdown | Paragraphs split on blank lines, `---` between pages. |
+| HTML | Each paragraph in `<p>`, entities escaped, `<hr class="page-break">` between pages. |
+
+The uploaded PDF is then deleted, whatever the outcome — success, failure or cancellation.
+
+## Where the state lives
+
+One JSON file per conversion under `<UPLOAD_FOLDER>/.tasks/`, written with a
+write-then-rename so a reader never sees a partial file.
+
+This is what lets more than one gunicorn worker serve the same conversion: the upload lands
+on one worker and the status poll on another, and both read the same file. It also survives
+a restart.
+
+Cancellation uses a **separate** marker file rather than a field in that record. Updating the
+record is a read-modify-write with no locking, so a flag stored there would race with the
+per-page progress writes — the worker could read the record, the cancel could land, and the
+worker would then write its stale copy back, losing the cancellation with no trace.
+
+## Failure states
+
+| State | Meaning |
+|---|---|
+| `processing` | Running. `progress` and `step` say where. |
+| `completed` | Output written and downloadable. |
+| `failed` | Carries an `error`. |
+| `cancelled` | Stopped on request. Carries no error, because it is not one. |
+
+A conversion whose worker dies never reaches a terminal state on its own, so a record that
+has not progressed for `STALE_TASK_TIMEOUT` is reported as failed rather than left pending
+forever.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,70 @@
+# Security
+
+The authoritative copy is
+[SECURITY.md](https://github.com/fabriziosalmi/pdf-ocr/blob/main/SECURITY.md) in the
+repository. This page says the same things.
+
+## Reporting a vulnerability
+
+Report privately through
+[GitHub Security Advisories](https://github.com/fabriziosalmi/pdf-ocr/security/advisories/new),
+or by email to `fabrizio.salmi@gmail.com`. **Please do not open a public issue.**
+
+Expect an acknowledgement within a few days. This is a spare-time project: no formal SLA, no
+bug bounty. Only the latest commit on `main`, and the image built from it, is supported.
+
+## Threat model
+
+`pdf-ocr` is a **single-tenant, self-hosted tool**. It accepts an uploaded PDF and hands it to
+Poppler and an OCR engine — large C and C++ codebases that parse untrusted input. Putting it
+on the public internet exposes that parsing surface to anyone who finds it.
+
+### What it does provide
+
+- `SECRET_KEY` is required, so session cookies are signed with a stable key.
+- Uploads need a `.pdf` extension **and** the `%PDF-` magic bytes.
+- Upload size and page count are capped; pages render in small batches, so peak memory does
+  not scale with document length.
+- Engine, output format and language are validated against allowlists.
+- A conversion is readable only by the session that started it, and the result's path on disk
+  is never sent to the client.
+- Baseline security headers including a same-origin CSP. No third-party assets are loaded —
+  Tailwind is vendored.
+- The image runs as an unprivileged user (uid 10001).
+- Uploads, results and finished tasks are deleted automatically; a cancelled conversion
+  leaves nothing behind at all.
+- A conversion whose worker dies is reported as failed rather than left pending.
+- CodeQL (`security-extended`) runs on every push and pull request, and weekly.
+
+### What it does not provide
+
+- **No authentication.** Anyone who can reach the port can convert documents.
+- **No rate limiting.** OCR is CPU- and memory-intensive; a handful of concurrent uploads
+  will saturate a small host.
+- **No sandboxing** of Poppler or Tesseract beyond the container boundary.
+- **No encryption at rest** for uploaded or converted files.
+- **No CSRF tokens.** The session cookie is `SameSite=Lax`, which keeps mainstream browsers
+  from attaching it to a cross-site POST, but that is a mitigation rather than a guarantee.
+  State-changing routes rely on the session-ownership check.
+- **No audit log.** There is no identity to record.
+
+::: warning The container hardening is a runtime choice
+The image runs unprivileged on its own. The read-only root filesystem, dropped capabilities
+and `no-new-privileges` come from **how you run it** — `docker-compose.yml` sets them and the
+[deployment command](/guide/deployment) passes the equivalent flags. A bare `docker run`
+gives you neither.
+:::
+
+## Intended deployment
+
+A private network, or behind an authenticating reverse proxy, with TLS terminated in front
+and `SESSION_COOKIE_SECURE=true`.
+
+## Never set these in a deployment
+
+- **`FLASK_ENV=development`** enables the Werkzeug debugger: arbitrary code execution over
+  HTTP.
+- **`PDF_OCR_TESTING=1`** starts the app without `SECRET_KEY`, using a per-process key. The
+  test suite sets it so importing the app needs no configuration.
+
+Neither is set by the image, and neither is enabled in `.env.example`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2561 @@
+{
+  "name": "pdf-ocr-docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pdf-ocr-docs",
+      "devDependencies": {
+        "vitepress": "^1.6.4"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.23.0.tgz",
+      "integrity": "sha512-j45MBISstltys9QyQ4xf6quRiN1g7vMuwQL9VM4dx8YuRZvCQ173b9royZAx6iAbRX3IB1VnG1z//NuwyQ8jpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.57.0.tgz",
+      "integrity": "sha512-JVFFujiZUCguk5tz3LZr4fTQxqpIrj4/Jw3SI7kMljSqtfLxYn/s/TWH0J2s4iNfsDpxPhgFGMotCpmDI4kZ8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.57.0.tgz",
+      "integrity": "sha512-6KqECK4ED3JJQEoDrQWnGPQzElA828xAD4qK5ceawNNyP/LcSvzAoLHjFkoTPksZ/kxj6VUtCRH+IHZesLltng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.57.0.tgz",
+      "integrity": "sha512-uqpGF3oXYsoCbQq5d7BzNrNTfIfuvJyGP1CKvSW27T9boUg7KOwyxsAw1AX0a3jSW2HrYEJ/NN+Z4MiGivbpeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.57.0.tgz",
+      "integrity": "sha512-u5NboJVJXDEFplvNnqqX4CxkXPYysjJRj47hOSh9329H8kG5gFLKJBIiS5utMQ+GZm8xQl3Te7NInDk6elEADQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.57.0.tgz",
+      "integrity": "sha512-uzc0b2LmHAK9/QID4xeo35OG84AkZl4YewkCqawqAOGLjT2eZpM/OZx45ESygMHG30Ws+ZTSdluPtMJcUnrbWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.57.0.tgz",
+      "integrity": "sha512-dIAhnM6ue/ssa5PjgNfu4g8A4yTojl9ZOUzZU3wIaIKRerL2R/3Emuf9n/D6ICXXP167KC6XCeC7nliSw7cuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.57.0.tgz",
+      "integrity": "sha512-2TTPTTKSJmCptvhCm4Xf3bBYMqZni+Pgc2hVdqc4l9wsBpSJNVTVIKpnd10OubUgkGcmppVDj1XQqYaf6EnPSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.57.0.tgz",
+      "integrity": "sha512-W4JseHKt+pzOxlFV+T3MWEG0h4Z2Se5zjoXUD0ewlw8aOWMG/yjRdopUdLQsXULepB/My2tDuZjkwk2sMfsUrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.57.0.tgz",
+      "integrity": "sha512-BrxJVE0/eLinEPICCD7BKN/2xnt0nkjge70u8zzE2ISP3fuB3tjLgcwpanUycvlHBFLI4gK0l5ol54p6IYuR/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.57.0.tgz",
+      "integrity": "sha512-Gc29jkeiLKlVfHvyrIgyUHHE+aYTdXEeLfK42rjr5/1TTVsYwUJz0XkvoIBIqfMjcDg6gXeHb1jTUZ0H+SYIlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.57.0.tgz",
+      "integrity": "sha512-PIPnPN7MP3fp2VAi01BVXhCWmD366ZB2Hkq5TlYKtThd4KxUtMmaaNDpFgVCTXtSIqWVZLJntOHRvxg/sIPd8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.57.0.tgz",
+      "integrity": "sha512-AX3RlOudXMdTwtwUqdAf5hAVLvXfOZZH1FZh6ALDdrhVLT0TtAIe48N6nYcWcTnwoTxK/wDIQqZ19IMjK8zJAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.57.0.tgz",
+      "integrity": "sha512-cWZc1dKb7wy9/wPpwMtL1y89gK2G7y2A47Coa7zwf1ydtIeJm4+S+XxoQ2b/ZRiQnrC1YHavLjYUPDCdnT7Khg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.94",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.94.tgz",
+      "integrity": "sha512-l8UWzVxKaqZd9ABsE/M/9p6NyGkQnmCnOoZyhQmjlXCtY5PuL2rcWxOFk2l9pk7ux3ERMPkTLE4jl6kQpTkwxA==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-NoQ2yGlLWj4wpxMs+TYmRKk3thDrQ97agr7sFqfLsAlvoS8SNQuTrlObhFqG9iugdTtgOE9jpJ6FNM4ZGsa5xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
+      "integrity": "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.42.tgz",
+      "integrity": "sha512-2Ye1ilMtKXxl8qZUrQ5j0CdgenFp/HFQmta6rfRyfEsTG69L6Wk+tWuNoHYHMx9E8tF2Slvdg1FuwDvAXdy1LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.42",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.42.tgz",
+      "integrity": "sha512-qbhQZEFmycr+ni/qyuccS4sucNN7VAbDfbkvNxWOX2VfgFm90MNs3/UhRNKoPMEIVn0F8gdlYjLPvqxHwHeQOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.42.tgz",
+      "integrity": "sha512-fkCAFB4okcAANGMThboWnScp/gzWjU0ZSkVnjTIiplmMDq2uq0tIB3j+xVu4rhv5rvOgBySCysudmbMd6xRRqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-core": "3.5.42",
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/compiler-ssr": "3.5.42",
+        "@vue/shared": "3.5.42",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.19",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.42.tgz",
+      "integrity": "sha512-xmLk3wLkbizPAiLyomjgFFosf2ys9b5Ghb+oh/k2tnvipNz8OFrQOiTcWCzyK7MpBp9KkyGtfvgfLUivbmuGYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
+      "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.10"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
+      "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.10",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
+      "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.42.tgz",
+      "integrity": "sha512-TzNNfKpb7hDxbQltwAut8VDQA5YP+BuRlxntHUuRjyKwlMvmAPbs3unhCvieijifY6vFfVBwsS7wG/C7uq+bEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.42.tgz",
+      "integrity": "sha512-9uACtuHs7vJGkm5Bp3xu4xRDLFTIYy5DgxpToVjqGIAhAEKwQfsaLvKINhM6nFVp6bZPRFGdDqd1g52MqKsotA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.42.tgz",
+      "integrity": "sha512-rsCmhiWLaRxGltLwhlCWyYkFn7WAbKRh0q17eZ1A6Dq6eqc2ACQ61IIryxz0LrsvCzHSilLA9JHovVwM8CNE2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.42",
+        "@vue/runtime-core": "3.5.42",
+        "@vue/shared": "3.5.42",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.42.tgz",
+      "integrity": "sha512-2++5dUyYS4gvo7xQXSECUDhB7TS0aOl5SeVfC5qSq1Jgfhjvegw1zqhwTIR3imZ+QYPJQw9gfcFvXGAjGZ7ajQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.42",
+        "@vue/runtime-dom": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.42.tgz",
+      "integrity": "sha512-2rPxex1jQf4jvl9MOHl6YaXCPcrNqz/FstMOEh3QWY+/OME9nQTvl9WYeCwhW7AFjaR0SnngZGlp/wkR6rkI6g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.57.0.tgz",
+      "integrity": "sha512-HpND7MBGctOAkd1GoQoDZCGoCpqNTS5NG1LuhElFet3RdLJkwnyTYZXZhXwtpAQPrI36fqQ3eT6KQrdKDTKu3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.23.0",
+        "@algolia/client-abtesting": "5.57.0",
+        "@algolia/client-analytics": "5.57.0",
+        "@algolia/client-common": "5.57.0",
+        "@algolia/client-insights": "5.57.0",
+        "@algolia/client-personalization": "5.57.0",
+        "@algolia/client-query-suggestions": "5.57.0",
+        "@algolia/client-search": "5.57.0",
+        "@algolia/ingestion": "1.57.0",
+        "@algolia/monitoring": "1.57.0",
+        "@algolia/recommend": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.1.0.tgz",
+      "integrity": "sha512-ufbM3smX/Jbnpk5wcQjzd1MgBpzmqfNETUAyZNrGwU9foRlyHoGzMMBBCRzEhQLBjZfFDE1W2ufPXX2vdWkV8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.42.tgz",
+      "integrity": "sha512-4RyHQTbQvOPs3MfvUO1Sg0YRrKNnA0mAVtvpd12Tg1fKDN7OHBUl1IqSn8zGJjK9nI3NkNp8cgTpVrSZC5TTcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/compiler-sfc": "3.5.42",
+        "@vue/runtime-dom": "3.5.42",
+        "@vue/server-renderer": "3.5.42",
+        "@vue/shared": "3.5.42"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "pdf-ocr-docs",
+  "private": true,
+  "type": "module",
+  "description": "Documentation site for pdf-ocr. The application itself is Python; this package only builds the docs.",
+  "scripts": {
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs"
+  },
+  "devDependencies": {
+    "vitepress": "^1.6.4"
+  }
+}

--- a/scripts/check_docs_match_code.py
+++ b/scripts/check_docs_match_code.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Fail if the documentation and the code disagree about the public surface.
+
+This exists because the documentation drifted badly once already: a stale line
+count, two wrong test counts, a wrong CI matrix, an endpoint that appeared
+nowhere, and a `.env.example` the README told people to copy that had never
+been committed. Prose cannot be checked automatically, but the two lists that
+drifted hardest can be:
+
+  * environment variables the code reads
+  * HTTP routes the app serves
+
+Run from the repository root:  python scripts/check_docs_match_code.py
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Internal, deliberately undocumented in the user-facing config table: it is set
+# by the test suite so importing the app needs no configuration. SECURITY.md
+# does name it, as something never to set in a deployment.
+INTERNAL_ENV = {"PDF_OCR_TESTING"}
+
+DOCS = [
+    ROOT / "README.md",
+    ROOT / "docs" / "reference" / "configuration.md",
+]
+ENDPOINT_DOCS = [
+    ROOT / "README.md",
+    ROOT / "docs" / "reference" / "endpoints.md",
+]
+
+
+def env_vars_in_code() -> set[str]:
+    app = (ROOT / "app.py").read_text(encoding="utf-8")
+    entrypoint = (ROOT / "entrypoint.sh").read_text(encoding="utf-8")
+    found = set(re.findall(r"env_int\(\s*'([A-Z_]+)'", app))
+    found |= set(re.findall(r"environ\.get\(\s*'([A-Z_]+)'", app))
+    found |= set(re.findall(r"\$\{([A-Z_]+)", entrypoint))
+    return found - INTERNAL_ENV
+
+
+def routes_in_code() -> set[str]:
+    app = (ROOT / "app.py").read_text(encoding="utf-8")
+    return set(re.findall(r"@app\.route\(\s*'([^']+)'", app))
+
+
+def check(kind: str, expected: set[str], docs: list[Path]) -> list[str]:
+    problems = []
+    for doc in docs:
+        if not doc.exists():
+            problems.append(f"{doc.relative_to(ROOT)}: missing")
+            continue
+        text = doc.read_text(encoding="utf-8")
+        for item in sorted(expected):
+            if f"`{item}`" not in text:
+                problems.append(
+                    f"{doc.relative_to(ROOT)}: {kind} `{item}` is in the code but not documented"
+                )
+    return problems
+
+
+def main() -> int:
+    problems: list[str] = []
+
+    env = env_vars_in_code()
+    problems += check("env var", env, DOCS)
+
+    routes = routes_in_code()
+    problems += check("route", routes, ENDPOINT_DOCS)
+
+    # The other direction: a documented env var that no longer exists.
+    documented = set()
+    for doc in DOCS:
+        if doc.exists():
+            documented |= set(re.findall(r"^\|\s*`([A-Z_]+)`", doc.read_text(encoding="utf-8"), re.M))
+    for stale in sorted(documented - env - INTERNAL_ENV):
+        problems.append(f"env var `{stale}` is documented but the code no longer reads it")
+
+    if problems:
+        print("Documentation does not match the code:\n", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        print(f"\n{len(problems)} problem(s).", file=sys.stderr)
+        return 1
+
+    print(f"Docs match the code: {len(env)} environment variables, {len(routes)} routes.")
+    return 0
+
+
+if __name__ == "__main__":
+    os.chdir(ROOT)
+    sys.exit(main())


### PR DESCRIPTION
The README had become the only documentation, and it had already drifted far enough to need a claim-by-claim audit. A site gives the reference material somewhere to live at length. **The check is what stops it drifting again.**

## The site

Deployed to GitHub Pages at `https://fabriziosalmi.github.io/pdf-ocr/`.

- **Guide** — introduction, quickstart, installation, OCR engines, deployment, troubleshooting.
- **Reference** — every environment variable, every HTTP endpoint, and a walkthrough of the five stages of a conversion, written so a failure can be located to a stage.
- **Security** — the threat model, mirroring `SECURITY.md`.
- **Privacy** — separates what the *application* does (sends nothing, stores your files on your disk, no telemetry) from what this *site* does (static files on GitHub Pages, no analytics, no cookies, search runs in the browser). It names the one honest caveat: EasyOCR and PaddleOCR download language models from their own infrastructure on first use. That is a download, not an upload, but it is an outbound connection and it is theirs.

## Discovery and machine-readability

| File | Notes |
|---|---|
| `sitemap.xml` | Generated at build time with the real hostname; 12 URLs. |
| `robots.txt` | Points at the sitemap. |
| `.well-known/security.txt` | RFC 9116, scoped to the project rather than to anyone's deployment. |
| `llms.txt` | Leads with the five things a model most often gets wrong here. |
| JSON-LD | schema.org `SoftwareApplication`, on every page. |

`llms.txt` opens with the corrections rather than the links: single-user and self-hosted, `SECRET_KEY` mandatory, container hardening is a **runtime flag** and not a property of the image, PaddleOCR pinned to 2.x, Python 3.11–3.14.

## The anti-drift check

`scripts/check_docs_match_code.py` compares the environment variables the code reads and the routes it registers against what `README.md` and the reference pages document — **in both directions**, so a variable that disappears from the code also fails.

It runs in CI and again in the docs build. It found a real gap on its first run: `/new_conversion` is served, but only its task-scoped variant was documented.

The build also fails on a dead internal link. `localhost` is exempted by pattern rather than by disabling the check, since that is where the app runs.

## Note

GitHub Pages needs to be switched to the *GitHub Actions* source for the deploy job to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)