### PR TITLE
Add .nojekyll so Pages serves .well-known/security.txt

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,6 +61,10 @@ jobs:
           for f in llms.txt robots.txt sitemap.xml favicon.svg .well-known/security.txt; do
             test -s "docs/.vitepress/dist/$f" || { echo "missing or empty: $f"; exit 1; }
           done
+          # Without .nojekyll, Pages drops anything whose path starts with a
+          # dot — which silently 404'd .well-known/security.txt even though it
+          # was present in the build output.
+          test -f docs/.vitepress/dist/.nojekyll || { echo "missing .nojekyll"; exit 1; }
           grep -q 'application/ld+json' docs/.vitepress/dist/index.html \
             || { echo "JSON-LD missing from the home page"; exit 1; }
           echo "all present"


### PR DESCRIPTION
`.well-known/security.txt` was in the build output, and the docs workflow verified it was there — but the deployed site returned **404** for it. GitHub Pages drops paths beginning with a dot unless a `.nojekyll` marker is present.

Worth noting how this slipped through: the check passed while the live site was missing the file. **Verifying the artifact is not the same as verifying what is served.** Adds the marker and asserts it in the same step so it cannot regress quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)